### PR TITLE
Add availability to use different logic with execute on retries

### DIFF
--- a/distributed-task-library/src/main/java/com/distributed_task_framework/service/impl/workers/LocalAtLeastOnceWorker.java
+++ b/distributed-task-library/src/main/java/com/distributed_task_framework/service/impl/workers/LocalAtLeastOnceWorker.java
@@ -360,7 +360,11 @@ public class LocalAtLeastOnceWorker implements TaskWorker {
                 .executionAttempt(taskEntity.getFailures() + 1)
                 .build();
 
-            task.execute(executionContext);
+            if (executionContext.getExecutionAttempt() == 1) {
+                task.execute(executionContext);
+            } else {
+                task.reExecute(executionContext);
+            }
         }
 
         TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);

--- a/distributed-task-library/src/main/java/com/distributed_task_framework/task/Task.java
+++ b/distributed-task-library/src/main/java/com/distributed_task_framework/task/Task.java
@@ -39,4 +39,16 @@ public interface Task<T> {
         onFailure(failedExecutionContext);
         return false;
     }
+
+    /**
+     * Called when the task is executed again.
+     * By default, it uses the same logic as the {@link #execute(ExecutionContext)} method,
+     * but it can be overridden to provide custom re-execution logic.
+     *
+     * @param executionContext The context in which the task is re-executed.
+     * @throws Exception If an error occurs during task re-execution.
+     */
+    default void reExecute(ExecutionContext<T> executionContext) throws Exception {
+        execute(executionContext);
+    }
 }

--- a/distributed-task-library/src/test/java/com/distributed_task_framework/service/impl/workers/local/AbstractLocalWorkerIntegrationTests.java
+++ b/distributed-task-library/src/test/java/com/distributed_task_framework/service/impl/workers/local/AbstractLocalWorkerIntegrationTests.java
@@ -518,6 +518,27 @@ public abstract class AbstractLocalWorkerIntegrationTests extends BaseLocalWorke
         verifyLocalTaskIsFinished(taskEntity);
     }
 
+    @SuppressWarnings("unchecked")
+    @SneakyThrows
+    @Test
+    void shouldReExecuteTaskWhenAttemptsMoreThanOnce() {
+        //when
+        TaskDef<String> taskDef = TaskDef.privateTaskDef("test", String.class);
+        TaskSettings taskSettings = defaultTaskSettings.toBuilder().build();
+        Task<String> mockedTask = (Task<String>) Mockito.mock(Task.class);
+        when(mockedTask.getDef()).thenReturn(taskDef);
+
+        RegisteredTask<String> registeredTask = RegisteredTask.of(mockedTask, taskSettings);
+        TaskEntity taskEntity = saveNewTaskEntity(1);
+
+        //do
+        getTaskWorker().execute(taskEntity, registeredTask);
+
+        //verify
+        verify(mockedTask).reExecute(any(ExecutionContext.class));
+        verifyLocalTaskIsFinished(taskEntity);
+    }
+
     @Value
     @Builder
     @Jacksonized


### PR DESCRIPTION
I have added a new method, reExecute, to the Task interface in the task-processor library. This method is intended to handle retry logic for tasks that need to be reprocessed after an initial failure.

The current implementation only relies on a single execute method, which does not differentiate between the initial execution of a task and subsequent retry attempts. By introducing the reExecute method, developers using the library can implement custom logic specifically for retry scenarios. This allows for more flexibility, such as modifying task parameters, logging retries separately, or implementing different processing behavior for retries.

I believe this addition will make the task-processor more versatile and developer-friendly, as it provides a clear mechanism for handling retries without complicating the existing execute method. And I just need it to use this library in our project) 