### PR TITLE
Autoregister Jackson modules using service loader

### DIFF
--- a/distributed-task-spring-boot-autoconfigure/build.gradle
+++ b/distributed-task-spring-boot-autoconfigure/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+    testRuntimeOnly("com.fasterxml.jackson.module:jackson-module-kotlin")
 }
 
 tasks.register('generateAdoc') {

--- a/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/DistributedTaskAutoconfigure.java
+++ b/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/DistributedTaskAutoconfigure.java
@@ -384,6 +384,7 @@ public class DistributedTaskAutoconfigure {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
         objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.findAndRegisterModules();
         return objectMapper;
     }
 

--- a/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/TaskSerializerConfiguration.java
+++ b/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/TaskSerializerConfiguration.java
@@ -1,0 +1,49 @@
+package com.distributed_task_framework.autoconfigure;
+
+import com.distributed_task_framework.autoconfigure.annotation.DtfDataSource;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+import static org.mockito.Mockito.when;
+
+
+@TestConfiguration
+@ActiveProfiles("test")
+public class TaskSerializerConfiguration {
+    @Primary
+    @Bean
+    public DataSource primaryDataSource() throws SQLException {
+        final DataSource dataSource = mockDataSource();
+        when(dataSource.toString()).thenReturn("primary");
+        return dataSource;
+    }
+
+    @Bean
+    @DtfDataSource
+    public DataSource dtfDataSource() throws SQLException {
+        final DataSource dataSource = mockDataSource();
+        when(dataSource.toString()).thenReturn("dtf");
+        return dataSource;
+    }
+
+    private DataSource mockDataSource() throws SQLException {
+        final DataSource dataSource = Mockito.mock(DataSource.class);
+        final Connection connection = Mockito.mock(Connection.class);
+        final DatabaseMetaData metadata = Mockito.mock(DatabaseMetaData.class);
+
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.getMetaData()).thenReturn(metadata);
+        when(metadata.getDatabaseProductName()).thenReturn("PostgreSQL");
+
+        return dataSource;
+    }
+
+}

--- a/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/TaskSerializerTest.java
+++ b/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/TaskSerializerTest.java
@@ -1,0 +1,39 @@
+package com.distributed_task_framework.autoconfigure;
+
+import com.distributed_task_framework.service.TaskSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    properties = {
+        "distributed-task.enabled=true",
+        "distributed-task.common.app-name=test"
+    })
+@ContextConfiguration(classes = {
+    TaskSerializerConfiguration.class,
+    DataSourceAutoConfiguration.class,
+    JdbcTemplateAutoConfiguration.class,
+    DistributedTaskAutoconfigure.class
+})
+@EnableAutoConfiguration
+public class TaskSerializerTest {
+    @Autowired
+    TaskSerializer taskSerializer;
+
+    @Test
+    void shouldHaveKotlinModule() {
+        ObjectMapper objectMapper = (ObjectMapper) ReflectionTestUtils.getField(taskSerializer, "objectMapper");
+        Assertions.assertThat(objectMapper.getRegisteredModuleIds())
+            .contains("com.fasterxml.jackson.module.kotlin.KotlinModule");
+    }
+}


### PR DESCRIPTION
When we use Kotlin, we have issue with serialization data classes as task input.