### PR TITLE
introduce task metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ communication mean) to start task execution in another service.
 - Prevent concurrent task execution that works with common resource: affinity and affinity group.
 - Workflow support. Makes it possible to organize tasks in a groups.
 - Map-Reduce tasks. Allows parallelizing computations and collect results on a last step. 
+- Metadata for tasks with creation and execution interceptors.
 - Configurable with settings, or spring properties, or annotations.
 
 ## Install
@@ -757,6 +758,135 @@ flowchart TD
     
     classDef join stroke:#f00
 ```
+
+### Metadata
+Metadata is an arbitrary multi-value string map (`Metadata` value object wrapping `Map<String, List<String>>`)
+attached to a task at schedule time and available at execution time via `ExecutionContext#getMetadata()`.
+It can be used to pass tracing information, tenants, feature flags and so on. Metadata is stored with the
+task, so it survives retries, is copied to the dead letter table and is transferred with remote tasks.
+The `Metadata` value object is immutable: modification methods return a new instance.
+
+Metadata can be set via API:
+```java
+distributedTaskService.schedule(
+    MY_TASK_DEF,
+    ExecutionContext.simple(new MyMessage())
+        .toBuilder()
+        .metadata(Metadata.of("traceId", "123"))
+        .build()
+);
+```
+Metadata is inherited by child tasks scheduled with `withNewMessage()` / `withEmptyMessage()`.
+
+To add metadata automatically, implement a `TaskCreationInterceptor`:
+```java
+@Component
+public class TraceIdCreationInterceptor implements TaskCreationInterceptor {
+    @Override
+    public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+        // the returned context is used to build the task
+        return executionContext.withMetadata(executionContext.getMetadata().add("traceId", MDC.get("traceId")));
+    }
+}
+```
+To process metadata of every task in a common implementation, implement a `TaskExecutionInterceptor`:
+```java
+@Component
+public class TracingExecutionInterceptor implements TaskExecutionInterceptor {
+    @Override
+    public <U> void execute(ExecutionContext<U> executionContext, TaskDef<U> taskDef, TaskExecutionChain chain) throws Exception {
+        String traceId = executionContext.getMetadata().getSingle("traceId").orElse("unknown");
+        try (var ignored = MDC.putCloseable("traceId", traceId)) {
+            chain.proceed(); // runs the next interceptor or the task itself
+        }
+    }
+}
+```
+
+Interceptors can be attached to tasks by class in the config (an interface or a base class can be used as well).
+Defaults are applied to all tasks:
+```yaml
+distributed-task:
+  task-properties-group:
+    default-properties:
+      creation-interceptors:
+        - com.example.TraceIdCreationInterceptor
+      execution-interceptors:
+        - com.example.TracingExecutionInterceptor
+```
+or per task:
+```yaml
+distributed-task:
+  task-properties-group:
+    task-properties:
+      MY_TASK_DEF:
+        creation-interceptors:
+          - com.example.MyTaskCreationInterceptor
+        execution-interceptors:
+          - com.example.MyTaskExecutionInterceptor
+```
+or with annotations:
+```java
+@Component
+@TaskCreationInterceptors(MyTaskCreationInterceptor.class)
+@TaskExecutionInterceptors(MyTaskExecutionInterceptor.class)
+public class MyTask implements Task<MyMessage> {
+    ...
+}
+```
+
+### Common interceptors
+An interceptor implemented with the `CommonTaskCreationInterceptor` / `CommonTaskExecutionInterceptor` marker
+is applied to all tasks by default: it is invoked even if not attached to a task in the config,
+it is enough to declare a bean. Common interceptors run before configured ones.
+```java
+@Component
+public class TracingCreationInterceptor implements CommonTaskCreationInterceptor {
+    ...
+}
+```
+A common interceptor can be excluded for a specific task:
+```yaml
+distributed-task:
+  task-properties-group:
+    task-properties:
+      MY_TASK_DEF:
+        excluded-common-creation-interceptors:
+          - com.example.TracingCreationInterceptor
+        excluded-common-execution-interceptors:
+          - com.example.TracingExecutionInterceptor
+```
+or with annotations:
+```java
+@Component
+@TaskCreationInterceptors(excludedCommon = TracingCreationInterceptor.class)
+@TaskExecutionInterceptors(excludedCommon = TracingExecutionInterceptor.class)
+public class MyTask implements Task<MyMessage> {
+    ...
+}
+```
+
+See the working example in the [test application](examples%2Fdistributed-task-test-application%2Fsrc%2Fmain%2Fjava%2Fcom%2Fdistributed_task_framework%2Ftest_service%2Ftasks%2Fmetadata%2FMetadataExampleTask.java):
+API metadata in the [controller](examples%2Fdistributed-task-test-application%2Fsrc%2Fmain%2Fjava%2Fcom%2Fdistributed_task_framework%2Ftest_service%2Fcontrollers%2FTestTaskController.java),
+interceptors in the [metadata package](examples%2Fdistributed-task-test-application%2Fsrc%2Fmain%2Fjava%2Fcom%2Fdistributed_task_framework%2Ftest_service%2Ftasks%2Fmetadata)
+attached via `@TaskCreationInterceptors` / `@TaskExecutionInterceptors` annotations on the task,
+and the yaml alternative (per-task and default for all tasks) commented out in [application.yml](examples%2Fdistributed-task-test-application%2Fsrc%2Fmain%2Fresources%2Fapplication.yml).
+
+Semantics:
+- The final interceptor list is composed of yaml `default-properties`, then annotations, then yaml per-task
+  and deduplicated. A per-task config cannot exclude a default interceptor.
+- Common interceptors are applied to all tasks unless excluded via `excluded-common-creation-interceptors` /
+  `excluded-common-execution-interceptors` (or the `excludedCommon` annotation argument);
+  exclusions are composed of annotations and yaml per-task and deduplicated.
+  It is prohibited to set exclusions in `default-properties` (an application startup fails).
+- Interceptors are executed in the configured order, `@Order` / `Ordered` is respected.
+- Metadata is effectively read-only at execution: changes made by a task are not persisted.
+- A thrown exception in a creation interceptor aborts scheduling; in an execution interceptor it is treated
+  as an ordinary task failure (retry policy and dead letter table are applied).
+- Only common creation interceptors are applied to cluster-only tasks scheduled with `scheduleUnsafe()`.
+- If a configured interceptor class is not registered as a bean, the framework fails fast with an error.
+
+## Planner
 
 ## Planner
 Planner is a central unit that assigns tasks to workers depending on worker load, number of tasks and configuration.

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/interceptor/CommonTaskCreationInterceptor.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/interceptor/CommonTaskCreationInterceptor.java
@@ -1,0 +1,10 @@
+package com.distributed_task_framework.interceptor;
+
+/**
+ * Marker of a creation interceptor applied to all tasks by default:
+ * it is invoked even if not attached to a task in the config, it is enough to declare a bean.
+ * Can be excluded for a specific task via {@code excluded-common-interceptors} config
+ * or {@code @TaskExcludedCommonInterceptors} annotation.
+ */
+public interface CommonTaskCreationInterceptor extends TaskCreationInterceptor {
+}

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/interceptor/CommonTaskExecutionInterceptor.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/interceptor/CommonTaskExecutionInterceptor.java
@@ -1,0 +1,10 @@
+package com.distributed_task_framework.interceptor;
+
+/**
+ * Marker of an execution interceptor applied to all tasks by default:
+ * it is invoked even if not attached to a task in the config, it is enough to declare a bean.
+ * Can be excluded for a specific task via {@code excluded-common-interceptors} config
+ * or {@code @TaskExcludedCommonInterceptors} annotation.
+ */
+public interface CommonTaskExecutionInterceptor extends TaskExecutionInterceptor {
+}

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/interceptor/TaskCreationInterceptor.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/interceptor/TaskCreationInterceptor.java
@@ -1,0 +1,26 @@
+package com.distributed_task_framework.interceptor;
+
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.Metadata;
+import com.distributed_task_framework.model.TaskDef;
+import org.springframework.lang.NonNull;
+
+/**
+ * Interceptor invoked at schedule time before the task is persisted.
+ * <p>
+ * Implementations have to be registered as Spring beans and can be attached to tasks
+ * by class (an interface or a base class can be used as well)
+ * via yaml or {@code @TaskCreationInterceptors} annotation, or as defaults for all tasks.
+ * <p>
+ * A thrown exception aborts scheduling and the transaction is rolled back.
+ */
+public interface TaskCreationInterceptor {
+    /**
+     * The returned execution context is used to build the task,
+     * so the interceptor can add metadata (e.g. via {@link ExecutionContext#withMetadata(Metadata)}
+     * and {@link Metadata#add(String, String)}).
+     */
+    @NonNull
+    <U> ExecutionContext<U> onTaskCreated(@NonNull ExecutionContext<U> executionContext,
+                                          @NonNull TaskDef<U> taskDef) throws Exception;
+}

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/interceptor/TaskExecutionChain.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/interceptor/TaskExecutionChain.java
@@ -1,0 +1,12 @@
+package com.distributed_task_framework.interceptor;
+
+/**
+ * Chain of execution interceptors ended with the task itself.
+ */
+@FunctionalInterface
+public interface TaskExecutionChain {
+    /**
+     * Continue execution: invoke the next interceptor or the task.
+     */
+    void proceed() throws Exception;
+}

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/interceptor/TaskExecutionInterceptor.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/interceptor/TaskExecutionInterceptor.java
@@ -1,0 +1,25 @@
+package com.distributed_task_framework.interceptor;
+
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.TaskDef;
+import org.springframework.lang.NonNull;
+
+/**
+ * Around-style interceptor invoked around task execution.
+ * <p>
+ * Implementations have to be registered as Spring beans and can be attached to tasks
+ * by class (an interface or a base class can be used as well)
+ * via yaml or {@code @TaskExecutionInterceptors} annotation, or as defaults for all tasks.
+ * <p>
+ * A thrown exception (either from the interceptor itself or from the chain) is treated
+ * as an ordinary task failure: the retry policy and DLT are applied.
+ */
+@FunctionalInterface
+public interface TaskExecutionInterceptor {
+    /**
+     * @param chain has to be invoked to run the next interceptor or the task itself
+     */
+    <U> void execute(@NonNull ExecutionContext<U> executionContext,
+                     @NonNull TaskDef<U> taskDef,
+                     @NonNull TaskExecutionChain chain) throws Exception;
+}

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/model/ExecutionContext.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/model/ExecutionContext.java
@@ -75,6 +75,13 @@ public class ExecutionContext<T> {
      */
     int executionAttempt;
 
+    /**
+     * Metadata attached to the task at schedule time via API or by creation interceptors.
+     * Immutable and read-only during execution: changes made by a task are not persisted.
+     */
+    @Builder.Default
+    Metadata metadata = Metadata.empty();
+
     public static <T> ExecutionContext<T> empty() {
         return ExecutionContext.<T>builder()
                 .workflowId(UUID.randomUUID())
@@ -130,6 +137,7 @@ public class ExecutionContext<T> {
                 .affinity(this.affinity)
                 .affinityGroup(this.affinityGroup)
                 .inputMessage(inputMessage)
+                .metadata(this.metadata)
                 .build();
     }
 
@@ -146,6 +154,27 @@ public class ExecutionContext<T> {
                 .affinity(this.affinity)
                 .affinityGroup(this.affinityGroup)
                 .inputMessage(null)
+                .metadata(this.metadata)
+                .build();
+    }
+
+    /**
+     * Reuse settings of current context in order to create new one with other metadata only.
+     *
+     * @param metadata
+     * @return
+     */
+    public ExecutionContext<T> withMetadata(Metadata metadata) {
+        return ExecutionContext.<T>builder()
+                .workflowId(this.getWorkflowId())
+                .workflowCreatedDateUtc(this.getWorkflowCreatedDateUtc())
+                .affinity(this.affinity)
+                .affinityGroup(this.affinityGroup)
+                .currentTaskId(this.currentTaskId)
+                .inputMessage(this.inputMessage)
+                .inputJoinTaskMessages(this.inputJoinTaskMessages)
+                .executionAttempt(this.executionAttempt)
+                .metadata(metadata)
                 .build();
     }
 

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/model/Metadata.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/model/Metadata.java
@@ -1,0 +1,205 @@
+package com.distributed_task_framework.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.springframework.lang.NonNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable metadata of a task: a multi-value string map.
+ * Serialized to JSON as a plain map: {@code {"key": ["value1", "value2"]}}.
+ * All modification methods return a new instance.
+ */
+@EqualsAndHashCode
+@ToString
+public class Metadata {
+    private static final Metadata EMPTY = new Metadata(Map.of());
+
+    private final Map<String, List<String>> values;
+
+    private Metadata(Map<String, List<String>> values) {
+        this.values = copyOf(values);
+    }
+
+    public static @NonNull Metadata empty() {
+        return EMPTY;
+    }
+
+    /**
+     * The map is deeply copied, so later changes of the source are not reflected.
+     */
+    @JsonCreator
+    public static @NonNull Metadata from(@NonNull Map<String, List<String>> values) {
+        Objects.requireNonNull(values, "values");
+        if (values.isEmpty()) {
+            return EMPTY;
+        }
+        return new Metadata(values);
+    }
+
+    public static @NonNull Metadata of(@NonNull String key, @NonNull String value) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(value, "value");
+        return new Metadata(Map.of(key, List.of(value)));
+    }
+
+    /**
+     * @return metadata as an unmodifiable map
+     */
+    @JsonValue
+    public @NonNull Map<String, List<String>> asMap() {
+        return values;
+    }
+
+    /**
+     * @return values for the key or empty list if the key is absent
+     */
+    public @NonNull List<String> get(@NonNull String key) {
+        Objects.requireNonNull(key, "key");
+        return values.getOrDefault(key, List.of());
+    }
+
+    /**
+     * @return first value for the key if present
+     */
+    public @NonNull Optional<String> getSingle(@NonNull String key) {
+        Objects.requireNonNull(key, "key");
+        return Optional.ofNullable(values.get(key)).flatMap(valueList -> valueList.stream().findFirst());
+    }
+
+    /**
+     * @throws IllegalArgumentException if the key is absent or has no values
+     */
+    public @NonNull String getSingleOrThrow(@NonNull String key) {
+        return getSingle(key).orElseThrow(
+            () -> new IllegalArgumentException("Metadata: no value for key=[%s]".formatted(key))
+        );
+    }
+
+    public boolean containsKey(@NonNull String key) {
+        Objects.requireNonNull(key, "key");
+        return values.containsKey(key);
+    }
+
+    public boolean containsValue(@NonNull String key, @NonNull String value) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(value, "value");
+        return values.getOrDefault(key, List.of()).contains(value);
+    }
+
+    public boolean isEmpty() {
+        return values.isEmpty();
+    }
+
+    public int size() {
+        return values.size();
+    }
+
+    /**
+     * Add the value to existing values of the key.
+     */
+    public @NonNull Metadata add(@NonNull String key, @NonNull String value) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(value, "value");
+        return addAll(key, List.of(value));
+    }
+
+    /**
+     * Add the values to existing values of the key.
+     */
+    public @NonNull Metadata add(@NonNull String key, @NonNull String... values) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(values, "values");
+        return addAll(key, List.of(values));
+    }
+
+    public @NonNull Metadata addAll(@NonNull String key, @NonNull Collection<String> values) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(values, "values");
+        Map<String, List<String>> copy = toMutableCopy();
+        copy.computeIfAbsent(key, ignored -> new ArrayList<>()).addAll(values);
+        return new Metadata(copy);
+    }
+
+    /**
+     * Set the single value for the key, replacing existing values.
+     */
+    public @NonNull Metadata with(@NonNull String key, @NonNull String value) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(value, "value");
+        return with(key, List.of(value));
+    }
+
+    /**
+     * Set the values for the key, replacing existing values.
+     */
+    public @NonNull Metadata with(@NonNull String key, @NonNull Collection<String> values) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(values, "values");
+        Map<String, List<String>> copy = toMutableCopy();
+        copy.put(key, new ArrayList<>(values));
+        return new Metadata(copy);
+    }
+
+    /**
+     * Set the value for the key only if the key is absent.
+     *
+     * @return new metadata or this if the key is already present
+     */
+    public @NonNull Metadata withIfAbsent(@NonNull String key, @NonNull String value) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(value, "value");
+        return containsKey(key) ? this : with(key, value);
+    }
+
+    public @NonNull Metadata remove(@NonNull String key) {
+        Objects.requireNonNull(key, "key");
+        Map<String, List<String>> copy = toMutableCopy();
+        copy.remove(key);
+        return new Metadata(copy);
+    }
+
+    public @NonNull Metadata removeAll(@NonNull Collection<String> keys) {
+        Objects.requireNonNull(keys, "keys");
+        Map<String, List<String>> copy = toMutableCopy();
+        keys.forEach(copy::remove);
+        return new Metadata(copy);
+    }
+
+    /**
+     * Add all entries of the map, appending values by existing keys.
+     */
+    public @NonNull Metadata putAll(@NonNull Map<String, List<String>> other) {
+        Objects.requireNonNull(other, "other");
+        Map<String, List<String>> copy = toMutableCopy();
+        other.forEach((key, valuesToAdd) ->
+            copy.computeIfAbsent(key, ignored -> new ArrayList<>()).addAll(valuesToAdd)
+        );
+        return new Metadata(copy);
+    }
+
+    private Map<String, List<String>> toMutableCopy() {
+        Map<String, List<String>> copy = new LinkedHashMap<>();
+        values.forEach((key, valueList) -> copy.put(key, new ArrayList<>(valueList)));
+        return copy;
+    }
+
+    private static Map<String, List<String>> copyOf(Map<String, List<String>> source) {
+        Map<String, List<String>> copy = new LinkedHashMap<>();
+        source.forEach((key, valueList) -> copy.put(
+            key,
+            Collections.unmodifiableList(new ArrayList<>(valueList))
+        ));
+        return Collections.unmodifiableMap(copy);
+    }
+}

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/persistence/entity/DltEntity.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/persistence/entity/DltEntity.java
@@ -32,5 +32,7 @@ public class DltEntity {
     LocalDateTime executionDateUtc;
     @ToString.Exclude
     byte[] messageBytes;
+    @ToString.Exclude
+    byte[] metadataBytes;
     int failures;
 }

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/persistence/entity/TaskEntity.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/persistence/entity/TaskEntity.java
@@ -55,5 +55,8 @@ public class TaskEntity {
     @Nullable
     @ToString.Exclude
     byte[] joinMessageBytes;
+    @Nullable
+    @ToString.Exclude
+    byte[] metadataBytes;
     int failures;
 }

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/persistence/repository/jdbc/TaskExtendedRepositoryImpl.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/persistence/repository/jdbc/TaskExtendedRepositoryImpl.java
@@ -67,6 +67,7 @@ public class TaskExtendedRepositoryImpl implements TaskExtendedRepository {
             deleted_at,
             join_message_bytes,
             message_bytes,
+            metadata_bytes,
             failures
         ) VALUES (
             :id::uuid,
@@ -87,6 +88,7 @@ public class TaskExtendedRepositoryImpl implements TaskExtendedRepository {
             :deletedAt,
             :joinMessageBytes,
             :messageBytes,
+            :metadataBytes,
             :failures
         ) ON CONFLICT (id) DO UPDATE
             SET
@@ -101,6 +103,7 @@ public class TaskExtendedRepositoryImpl implements TaskExtendedRepository {
                 deleted_at = excluded.deleted_at,
                 join_message_bytes = excluded.join_message_bytes,
                 message_bytes = excluded.message_bytes,
+                metadata_bytes = excluded.metadata_bytes,
                 failures = excluded.failures
         WHERE _____dtf_tasks.version = :expectedVersion
         """;
@@ -401,6 +404,7 @@ public class TaskExtendedRepositoryImpl implements TaskExtendedRepository {
         parameterSource.addValue(TaskEntity.Fields.deletedAt, taskEntity.getDeletedAt(), Types.TIMESTAMP);
         parameterSource.addValue(TaskEntity.Fields.joinMessageBytes, taskEntity.getJoinMessageBytes(), Types.BINARY);
         parameterSource.addValue(TaskEntity.Fields.messageBytes, taskEntity.getMessageBytes(), Types.BINARY);
+        parameterSource.addValue(TaskEntity.Fields.metadataBytes, taskEntity.getMetadataBytes(), Types.BINARY);
         parameterSource.addValue(TaskEntity.Fields.failures, taskEntity.getFailures(), Types.INTEGER);
         parameterSource.addValue("expectedVersion", taskEntity.getVersion() - 1, Types.BIGINT);
 

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/service/TaskInterceptorProvider.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/service/TaskInterceptorProvider.java
@@ -1,0 +1,41 @@
+package com.distributed_task_framework.service;
+
+import com.distributed_task_framework.interceptor.TaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.TaskExecutionInterceptor;
+import com.distributed_task_framework.settings.TaskSettings;
+import org.springframework.lang.NonNull;
+
+import java.util.List;
+
+/**
+ * Resolves interceptors attached to a task by its settings.
+ */
+public interface TaskInterceptorProvider {
+    /**
+     * Common interceptors (minus excluded ones) first, then configured ones.
+     *
+     * @return interceptors in configured order
+     */
+    @NonNull
+    List<TaskCreationInterceptor> getCreationInterceptors(@NonNull TaskSettings taskSettings);
+
+    /**
+     * Common interceptors (minus excluded ones) first, then configured ones.
+     *
+     * @return interceptors in configured order
+     */
+    @NonNull
+    List<TaskExecutionInterceptor> getExecutionInterceptors(@NonNull TaskSettings taskSettings);
+
+    /**
+     * @return common creation interceptors in configured order
+     */
+    @NonNull
+    List<TaskCreationInterceptor> getCommonCreationInterceptors();
+
+    /**
+     * @return common execution interceptors in configured order
+     */
+    @NonNull
+    List<TaskExecutionInterceptor> getCommonExecutionInterceptors();
+}

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/service/impl/LocalTaskCommandServiceImpl.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/service/impl/LocalTaskCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.distributed_task_framework.exception.CronExpiredException;
 import com.distributed_task_framework.exception.OptimisticLockException;
 import com.distributed_task_framework.exception.TaskConfigurationException;
 import com.distributed_task_framework.exception.UnknownTaskException;
+import com.distributed_task_framework.interceptor.TaskCreationInterceptor;
 import com.distributed_task_framework.local_commands.impl.CancelByTaskDefCommand;
 import com.distributed_task_framework.local_commands.impl.CancelByWorkflowCommand;
 import com.distributed_task_framework.local_commands.impl.CancelCommand;
@@ -23,6 +24,7 @@ import com.distributed_task_framework.model.WorkerContext;
 import com.distributed_task_framework.persistence.entity.TaskEntity;
 import com.distributed_task_framework.persistence.entity.VirtualQueue;
 import com.distributed_task_framework.persistence.repository.TaskRepository;
+import com.distributed_task_framework.service.TaskInterceptorProvider;
 import com.distributed_task_framework.service.TaskSerializer;
 import com.distributed_task_framework.service.internal.CompletionService;
 import com.distributed_task_framework.service.internal.InternalTaskCommandService;
@@ -33,6 +35,7 @@ import com.distributed_task_framework.service.internal.WorkerContextManager;
 import com.distributed_task_framework.settings.CommonSettings;
 import com.distributed_task_framework.settings.TaskSettings;
 import com.google.common.collect.Lists;
+import jakarta.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
@@ -63,6 +66,7 @@ public class LocalTaskCommandServiceImpl extends AbstractTaskCommandWithDetector
     InternalTaskCommandService internalTaskCommandService;
     TaskLinkManager taskLinkManager;
     CompletionService completionService;
+    TaskInterceptorProvider taskInterceptorProvider;
     Clock clock;
 
     public LocalTaskCommandServiceImpl(WorkerContextManager workerContextManager,
@@ -76,6 +80,7 @@ public class LocalTaskCommandServiceImpl extends AbstractTaskCommandWithDetector
                                        InternalTaskCommandService internalTaskCommandService,
                                        TaskLinkManager taskLinkManager,
                                        CompletionService completionService,
+                                       TaskInterceptorProvider taskInterceptorProvider,
                                        Clock clock) {
         super(workerContextManager, transactionManager);
         this.taskRepository = taskRepository;
@@ -87,6 +92,7 @@ public class LocalTaskCommandServiceImpl extends AbstractTaskCommandWithDetector
         this.internalTaskCommandService = internalTaskCommandService;
         this.taskLinkManager = taskLinkManager;
         this.completionService = completionService;
+        this.taskInterceptorProvider = taskInterceptorProvider;
         this.clock = clock;
     }
 
@@ -133,21 +139,7 @@ public class LocalTaskCommandServiceImpl extends AbstractTaskCommandWithDetector
             throw new UnknownTaskException(taskDef);
         }
 
-        String taskName = taskDef.getTaskName();
-        Optional<T> inputMessageOpt = executionContext.getInputMessageOpt();
-        byte[] messageBytes = taskSerializer.writeValue(inputMessageOpt.orElse(null));
-
-        TaskEntity taskEntity = TaskEntity.builder()
-            .workflowId(executionContext.getWorkflowId())
-            .workflowCreatedDateUtc(
-                Optional.ofNullable(executionContext.getWorkflowCreatedDateUtc())
-                    .orElseGet(() -> LocalDateTime.now(clock))
-            )
-            .affinityGroup(executionContext.getAffinityGroup())
-            .affinity(executionContext.getAffinity())
-            .taskName(taskName)
-            .virtualQueue(VirtualQueue.NEW)
-            .messageBytes(messageBytes)
+        TaskEntity taskEntity = newTaskEntityBuilder(null, taskDef, executionContext)
             .executionDateUtc(LocalDateTime.now(clock))
             .singleton(false)
             .failures(0)
@@ -236,22 +228,9 @@ public class LocalTaskCommandServiceImpl extends AbstractTaskCommandWithDetector
                 ));
         }
 
-        String taskName = taskDef.getTaskName();
-        Optional<T> inputMessageOpt = executionContext.getInputMessageOpt();
-        byte[] messageBytes = taskSerializer.writeValue(inputMessageOpt.orElse(null));
         LocalDateTime now = LocalDateTime.now(clock);
 
-        TaskEntity taskEntity = TaskEntity.builder()
-            .workflowId(executionContext.getWorkflowId())
-            .workflowCreatedDateUtc(
-                Optional.ofNullable(executionContext.getWorkflowCreatedDateUtc())
-                    .orElse(now)
-            )
-            .affinityGroup(executionContext.getAffinityGroup())
-            .affinity(executionContext.getAffinity())
-            .taskName(taskName)
-            .virtualQueue(VirtualQueue.NEW)
-            .messageBytes(messageBytes)
+        TaskEntity taskEntity = newTaskEntityBuilder(registeredTask, taskDef, executionContext)
             .executionDateUtc(now)
             .singleton(false)
             .notToPlan(true)
@@ -354,6 +333,43 @@ public class LocalTaskCommandServiceImpl extends AbstractTaskCommandWithDetector
         );
     }
 
+    // common creation interceptors are applied even when the task is not registered locally
+    private TaskEntity.TaskEntityBuilder newTaskEntityBuilder(@Nullable RegisteredTask<?> registeredTask,
+                                                              TaskDef<?> taskDef,
+                                                              ExecutionContext<?> executionContext) throws Exception {
+        ExecutionContext<?> context = executionContext;
+        List<TaskCreationInterceptor> creationInterceptors = registeredTask != null ?
+            taskInterceptorProvider.getCreationInterceptors(registeredTask.getTaskSettings()) :
+            taskInterceptorProvider.getCommonCreationInterceptors();
+        for (TaskCreationInterceptor interceptor : creationInterceptors) {
+            context = applyCreationInterceptor(interceptor, taskDef, context);
+        }
+        byte[] metadataBytes = context.getMetadata().isEmpty() ? null : taskSerializer.writeValue(context.getMetadata());
+        byte[] messageBytes = taskSerializer.writeValue(context.getInputMessageOpt().orElse(null));
+        return TaskEntity.builder()
+            .workflowId(context.getWorkflowId())
+            .workflowCreatedDateUtc(
+                Optional.ofNullable(context.getWorkflowCreatedDateUtc())
+                    .orElseGet(() -> LocalDateTime.now(clock))
+            )
+            .affinityGroup(context.getAffinityGroup())
+            .affinity(context.getAffinity())
+            .taskName(taskDef.getTaskName())
+            .virtualQueue(VirtualQueue.NEW)
+            .messageBytes(messageBytes)
+            .metadataBytes(metadataBytes);
+    }
+
+    private ExecutionContext<?> applyCreationInterceptor(TaskCreationInterceptor interceptor,
+                                                         TaskDef<?> taskDef,
+                                                         ExecutionContext<?> executionContext) throws Exception {
+        //noinspection unchecked
+        TaskDef<Object> typedTaskDef = (TaskDef<Object>) taskDef;
+        //noinspection unchecked
+        ExecutionContext<Object> typedContext = (ExecutionContext<Object>) executionContext;
+        return interceptor.onTaskCreated(typedContext, typedTaskDef);
+    }
+
     /**
      * @noinspection unchecked
      */
@@ -379,9 +395,6 @@ public class LocalTaskCommandServiceImpl extends AbstractTaskCommandWithDetector
                 }
             }
 
-            Optional<T> inputMessageOpt = executionContext.getInputMessageOpt();
-            byte[] messageBytes = taskSerializer.writeValue(inputMessageOpt.orElse(null));
-
             final LocalDateTime executionDateUtc;
             String cron = registeredTask.getTaskSettings().getCron();
             if (StringUtils.hasText(cron)) {
@@ -392,17 +405,7 @@ public class LocalTaskCommandServiceImpl extends AbstractTaskCommandWithDetector
                 executionDateUtc = LocalDateTime.now(clock).plus(delay);
             }
 
-            TaskEntity taskEntity = TaskEntity.builder()
-                .workflowId(executionContext.getWorkflowId())
-                .workflowCreatedDateUtc(
-                    Optional.ofNullable(executionContext.getWorkflowCreatedDateUtc())
-                        .orElseGet(() -> LocalDateTime.now(clock))
-                )
-                .affinityGroup(executionContext.getAffinityGroup())
-                .affinity(executionContext.getAffinity())
-                .taskName(taskName)
-                .virtualQueue(VirtualQueue.NEW)
-                .messageBytes(messageBytes)
+            TaskEntity taskEntity = newTaskEntityBuilder(registeredTask, taskDef, executionContext)
                 .executionDateUtc(executionDateUtc)
                 .singleton(isSingleton)
                 .failures(0)

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/service/impl/TaskInterceptorProviderImpl.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/service/impl/TaskInterceptorProviderImpl.java
@@ -1,0 +1,113 @@
+package com.distributed_task_framework.service.impl;
+
+import com.distributed_task_framework.exception.TaskConfigurationException;
+import com.distributed_task_framework.interceptor.CommonTaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.CommonTaskExecutionInterceptor;
+import com.distributed_task_framework.interceptor.TaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.TaskExecutionInterceptor;
+import com.distributed_task_framework.service.TaskInterceptorProvider;
+import com.distributed_task_framework.settings.TaskSettings;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.lang.NonNull;
+import org.springframework.util.ClassUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Resolves interceptors by classes from {@link TaskSettings}.
+ * A configured class matches the first registered interceptor it is assignable from.
+ * A configured class without a registered bean fails fast.
+ */
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+public class TaskInterceptorProviderImpl implements TaskInterceptorProvider {
+    List<TaskCreationInterceptor> creationInterceptors;
+    List<TaskExecutionInterceptor> executionInterceptors;
+
+    public TaskInterceptorProviderImpl(@NonNull List<TaskCreationInterceptor> creationInterceptors,
+                                       @NonNull List<TaskExecutionInterceptor> executionInterceptors) {
+        this.creationInterceptors = creationInterceptors;
+        this.executionInterceptors = executionInterceptors;
+    }
+
+    @Override
+    public @NonNull List<TaskCreationInterceptor> getCreationInterceptors(@NonNull TaskSettings taskSettings) {
+        return combine(
+            getCommonCreationInterceptors(),
+            resolve(taskSettings.getCreationInterceptors(), creationInterceptors),
+            taskSettings.getExcludedCommonCreationInterceptors()
+        );
+    }
+
+    @Override
+    public @NonNull List<TaskExecutionInterceptor> getExecutionInterceptors(@NonNull TaskSettings taskSettings) {
+        return combine(
+            getCommonExecutionInterceptors(),
+            resolve(taskSettings.getExecutionInterceptors(), executionInterceptors),
+            taskSettings.getExcludedCommonExecutionInterceptors()
+        );
+    }
+
+    @Override
+    public @NonNull List<TaskCreationInterceptor> getCommonCreationInterceptors() {
+        return sort(creationInterceptors.stream()
+            .filter(CommonTaskCreationInterceptor.class::isInstance)
+            .toList()
+        );
+    }
+
+    @Override
+    public @NonNull List<TaskExecutionInterceptor> getCommonExecutionInterceptors() {
+        return sort(executionInterceptors.stream()
+            .filter(CommonTaskExecutionInterceptor.class::isInstance)
+            .toList()
+        );
+    }
+
+    private static <T> List<T> resolve(List<? extends Class<? extends T>> interceptorClasses,
+                                       List<T> interceptors) {
+        List<T> result = new ArrayList<>();
+        for (Class<? extends T> interceptorClass : interceptorClasses) {
+            T interceptor = interceptors.stream()
+                // proxy safe: resolves by the user class in case of CGLIB proxies
+                .filter(candidate -> interceptorClass.isAssignableFrom(ClassUtils.getUserClass(candidate)))
+                .findFirst()
+                .orElseThrow(() -> new TaskConfigurationException(
+                    "Interceptor=[%s] is not registered as a bean, available interceptors=%s".formatted(
+                        interceptorClass.getName(),
+                        interceptors.stream()
+                            .map(registered -> ClassUtils.getUserClass(registered).getName())
+                            .toList()
+                    )
+                ));
+            result.add(interceptor);
+        }
+        return result;
+    }
+
+    private static <T> List<T> combine(List<T> common, List<T> configured,
+                                       List<? extends Class<? extends T>> excludedCommon) {
+        List<T> result = new ArrayList<>(common);
+        for (T interceptor : configured) {
+            if (!result.contains(interceptor)) {
+                result.add(interceptor);
+            }
+        }
+        result.removeIf(interceptor -> isExcluded(interceptor, excludedCommon));
+        return sort(result);
+    }
+
+    private static <T> boolean isExcluded(T interceptor, List<? extends Class<? extends T>> excludedCommon) {
+        Class<?> userClass = ClassUtils.getUserClass(interceptor);
+        return excludedCommon.stream().anyMatch(excluded -> excluded.isAssignableFrom(userClass));
+    }
+
+    private static <T> List<T> sort(List<T> interceptors) {
+        List<T> sorted = new ArrayList<>(interceptors);
+        // stable: respects @Order/Ordered, keeps common interceptors before configured otherwise
+        sorted.sort(AnnotationAwareOrderComparator.INSTANCE);
+        return sorted;
+    }
+}

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/service/impl/workers/LocalAtLeastOnceWorker.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/service/impl/workers/LocalAtLeastOnceWorker.java
@@ -2,10 +2,13 @@ package com.distributed_task_framework.service.impl.workers;
 
 import com.distributed_task_framework.exception.BatchUpdateException;
 import com.distributed_task_framework.exception.OptimisticLockException;
+import com.distributed_task_framework.interceptor.TaskExecutionChain;
+import com.distributed_task_framework.interceptor.TaskExecutionInterceptor;
 import com.distributed_task_framework.mapper.TaskMapper;
 import com.distributed_task_framework.model.ExecutionContext;
 import com.distributed_task_framework.model.FailedExecutionContext;
 import com.distributed_task_framework.model.JoinTaskMessageContainer;
+import com.distributed_task_framework.model.Metadata;
 import com.distributed_task_framework.model.RegisteredTask;
 import com.distributed_task_framework.model.StateHolder;
 import com.distributed_task_framework.model.TaskId;
@@ -15,6 +18,7 @@ import com.distributed_task_framework.persistence.entity.TaskEntity;
 import com.distributed_task_framework.persistence.repository.DltRepository;
 import com.distributed_task_framework.persistence.repository.RemoteCommandRepository;
 import com.distributed_task_framework.persistence.repository.TaskRepository;
+import com.distributed_task_framework.service.TaskInterceptorProvider;
 import com.distributed_task_framework.service.TaskSerializer;
 import com.distributed_task_framework.service.impl.CronService;
 import com.distributed_task_framework.service.internal.ClusterProvider;
@@ -73,6 +77,7 @@ public class LocalAtLeastOnceWorker implements TaskWorker {
     TaskLinkManager taskLinkManager;
     DistributedTaskMetricHelper distributedTaskMetricHelper;
     Clock clock;
+    TaskInterceptorProvider taskInterceptorProvider;
 
     protected List<Tag> getCommonTags() {
         return COMMON_TAGS;
@@ -376,6 +381,19 @@ public class LocalAtLeastOnceWorker implements TaskWorker {
         }
     }
 
+    private Metadata readMetadata(TaskEntity taskEntity) {
+        if (taskEntity.getMetadataBytes() == null) {
+            return Metadata.empty();
+        }
+        try {
+            return taskSerializer.readValue(taskEntity.getMetadataBytes(), Metadata.class);
+        } catch (Exception e) {
+            getEngineErrorCounter(taskEntity).increment();
+            log.warn("readMetadata(): can't read metadata for taskId=[{}]", taskEntity.getId(), e);
+            return Metadata.empty();
+        }
+    }
+
     @SneakyThrows
     protected <T, U> void runInternal(final TaskEntity taskEntity, RegisteredTask<T> registeredTask) {
         TaskId taskId = taskMapper.map(taskEntity, commonSettings.getAppName());
@@ -403,6 +421,7 @@ public class LocalAtLeastOnceWorker implements TaskWorker {
                 .inputMessage(inputMessage)
                 .inputJoinTaskMessages(inputJoinTaskMessages)
                 .executionAttempt(taskEntity.getFailures() + 1)
+                .metadata(readMetadata(taskEntity))
                 .build();
 
             U localState = isStatefulTask && taskEntity.getLocalState() != null ?
@@ -413,12 +432,22 @@ public class LocalAtLeastOnceWorker implements TaskWorker {
                 .getStateHolder();
             stateHolder.set(localState);
 
-            if (isStatefulTask) {
-                //noinspection unchecked
-                statefulTaskOpt.get().execute(executionContext, (StateHolder<U>) stateHolder);
-            } else {
-                task.execute(executionContext);
+            TaskExecutionChain chain = () -> {
+                if (isStatefulTask) {
+                    //noinspection unchecked
+                    statefulTaskOpt.get().execute(executionContext, (StateHolder<U>) stateHolder);
+                } else {
+                    task.execute(executionContext);
+                }
+            };
+            //wrap in reverse order to keep the configured order of execution
+            List<TaskExecutionInterceptor> executionInterceptors = taskInterceptorProvider.getExecutionInterceptors(taskSettings);
+            for (int i = executionInterceptors.size() - 1; i >= 0; i--) {
+                TaskExecutionInterceptor interceptor = executionInterceptors.get(i);
+                TaskExecutionChain next = chain;
+                chain = () -> interceptor.execute(executionContext, task.getDef(), next);
             }
+            chain.proceed();
         }
 
         TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/service/impl/workers/LocalExactlyOnceWorker.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/service/impl/workers/LocalExactlyOnceWorker.java
@@ -2,6 +2,7 @@ package com.distributed_task_framework.service.impl.workers;
 
 import com.distributed_task_framework.mapper.TaskMapper;
 import com.distributed_task_framework.model.RegisteredTask;
+import com.distributed_task_framework.service.TaskInterceptorProvider;
 import com.distributed_task_framework.service.TaskSerializer;
 import io.micrometer.core.instrument.Tag;
 import lombok.AccessLevel;
@@ -46,7 +47,8 @@ public class LocalExactlyOnceWorker extends LocalAtLeastOnceWorker implements Ta
                                   CommonSettings commonSettings,
                                   TaskLinkManager taskLinkManager,
                                   DistributedTaskMetricHelper distributedTaskMetricHelper,
-                                  Clock clock) {
+                                  Clock clock,
+                                  TaskInterceptorProvider taskInterceptorProvider) {
         super(
                 clusterProvider,
                 workerContextManager,
@@ -60,8 +62,9 @@ public class LocalExactlyOnceWorker extends LocalAtLeastOnceWorker implements Ta
                 taskMapper,
                 commonSettings,
                 taskLinkManager,
-            distributedTaskMetricHelper,
-                clock
+                distributedTaskMetricHelper,
+                clock,
+                taskInterceptorProvider
         );
     }
 

--- a/core/distributed-task-library/src/main/java/com/distributed_task_framework/settings/TaskSettings.java
+++ b/core/distributed-task-library/src/main/java/com/distributed_task_framework/settings/TaskSettings.java
@@ -1,5 +1,9 @@
 package com.distributed_task_framework.settings;
 
+import com.distributed_task_framework.interceptor.CommonTaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.CommonTaskExecutionInterceptor;
+import com.distributed_task_framework.interceptor.TaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.TaskExecutionInterceptor;
 import com.distributed_task_framework.model.ExecutionContext;
 import com.distributed_task_framework.task.Task;
 import lombok.Builder;
@@ -8,6 +12,7 @@ import org.springframework.util.StringUtils;
 
 import jakarta.annotation.Nullable;
 import java.time.Duration;
+import java.util.List;
 
 /**
  * Configuration parameters for task.
@@ -65,6 +70,34 @@ public class TaskSettings {
     @Nullable
     @Builder.Default
     Duration timeout = Duration.ZERO;
+
+    /**
+     * Creation interceptors, composed of yaml default-properties, then annotations, then yaml per-task, deduplicated.
+     */
+    @Builder.Default
+    List<Class<? extends TaskCreationInterceptor>> creationInterceptors = List.of();
+
+    /**
+     * Execution interceptors, composed of yaml default-properties, then annotations, then yaml per-task, deduplicated.
+     */
+    @Builder.Default
+    List<Class<? extends TaskExecutionInterceptor>> executionInterceptors = List.of();
+
+    /**
+     * Common creation interceptors excluded for the task,
+     * composed of annotations and yaml per-task, deduplicated.
+     * It is prohibited to set exclusions in default-properties.
+     */
+    @Builder.Default
+    List<Class<? extends CommonTaskCreationInterceptor>> excludedCommonCreationInterceptors = List.of();
+
+    /**
+     * Common execution interceptors excluded for the task,
+     * composed of annotations and yaml per-task, deduplicated.
+     * It is prohibited to set exclusions in default-properties.
+     */
+    @Builder.Default
+    List<Class<? extends CommonTaskExecutionInterceptor>> excludedCommonExecutionInterceptors = List.of();
 
     public boolean hasCron() {
         return StringUtils.hasText(cron);

--- a/core/distributed-task-library/src/main/resources/db/changelog/distributed-task-framework/db.changelog-aggregator.yaml
+++ b/core/distributed-task-library/src/main/resources/db/changelog/distributed-task-framework/db.changelog-aggregator.yaml
@@ -7,3 +7,5 @@ databaseChangeLog:
       file: db/changelog/distributed-task-framework/db.changelog-dtf-003-feature-wait-task.yaml
   - include:
       file: db/changelog/distributed-task-framework/db.changelog-dtf-004-feature-statefull-task.yaml
+  - include:
+      file: db/changelog/distributed-task-framework/db.changelog-dtf-005-feature-metadata.yaml

--- a/core/distributed-task-library/src/main/resources/db/changelog/distributed-task-framework/db.changelog-dtf-005-feature-metadata.yaml
+++ b/core/distributed-task-library/src/main/resources/db/changelog/distributed-task-framework/db.changelog-dtf-005-feature-metadata.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: '5'
+      author: Pavel Lyubinskiy
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: db/changelog/distributed-task-framework/sql/005_dtf_feature_metadata.up.sql
+            encoding: UTF8
+      rollback:
+        - sqlFile:
+            dbms: postgresql
+            path: db/changelog/distributed-task-framework/sql/005_dtf_feature_metadata.down.sql
+            encoding: UTF8

--- a/core/distributed-task-library/src/main/resources/db/changelog/distributed-task-framework/sql/005_dtf_feature_metadata.down.sql
+++ b/core/distributed-task-library/src/main/resources/db/changelog/distributed-task-framework/sql/005_dtf_feature_metadata.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "_____dtf_tasks" DROP COLUMN "metadata_bytes";
+ALTER TABLE "_____dtf_dlt_tasks" DROP COLUMN "metadata_bytes";

--- a/core/distributed-task-library/src/main/resources/db/changelog/distributed-task-framework/sql/005_dtf_feature_metadata.up.sql
+++ b/core/distributed-task-library/src/main/resources/db/changelog/distributed-task-framework/sql/005_dtf_feature_metadata.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "_____dtf_tasks" ADD COLUMN "metadata_bytes" BYTEA NULL;
+ALTER TABLE "_____dtf_dlt_tasks" ADD COLUMN "metadata_bytes" BYTEA NULL;

--- a/core/distributed-task-library/src/test/java/com/distributed_task_framework/BaseTestConfiguration.java
+++ b/core/distributed-task-library/src/test/java/com/distributed_task_framework/BaseTestConfiguration.java
@@ -1,5 +1,7 @@
 package com.distributed_task_framework;
 
+import com.distributed_task_framework.interceptor.TaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.TaskExecutionInterceptor;
 import com.distributed_task_framework.mapper.CommandMapper;
 import com.distributed_task_framework.mapper.NodeStateMapper;
 import com.distributed_task_framework.mapper.PartitionMapper;
@@ -22,6 +24,7 @@ import com.distributed_task_framework.persistence.repository.TaskLinkRepository;
 import com.distributed_task_framework.persistence.repository.TaskMessageRepository;
 import com.distributed_task_framework.persistence.repository.TaskRepository;
 import com.distributed_task_framework.service.DistributedTaskService;
+import com.distributed_task_framework.service.TaskInterceptorProvider;
 import com.distributed_task_framework.service.TaskSerializer;
 import com.distributed_task_framework.service.impl.ClusterProviderImpl;
 import com.distributed_task_framework.service.impl.CompletionServiceImpl;
@@ -31,6 +34,7 @@ import com.distributed_task_framework.service.impl.InternalTaskCommandServiceImp
 import com.distributed_task_framework.service.impl.JoinTaskStatHelper;
 import com.distributed_task_framework.service.impl.JsonTaskSerializerImpl;
 import com.distributed_task_framework.service.impl.LocalTaskCommandServiceImpl;
+import com.distributed_task_framework.service.impl.TaskInterceptorProviderImpl;
 import com.distributed_task_framework.service.impl.DistributedTaskMetricHelperImpl;
 import com.distributed_task_framework.service.impl.PartitionTrackerImpl;
 import com.distributed_task_framework.service.impl.RemoteTaskCommandServiceImpl;
@@ -497,6 +501,12 @@ public class BaseTestConfiguration {
     }
 
     @Bean
+    public TaskInterceptorProvider taskInterceptorProvider(List<TaskCreationInterceptor> taskCreationInterceptors,
+                                                           List<TaskExecutionInterceptor> taskExecutionInterceptors) {
+        return new TaskInterceptorProviderImpl(taskCreationInterceptors, taskExecutionInterceptors);
+    }
+
+    @Bean
     public TaskCommandWithDetectorService localTaskCommandWithDetectorService(WorkerContextManager workerContextManager,
                                                                               PlatformTransactionManager transactionManager,
                                                                               TaskRepository taskRepository,
@@ -508,6 +518,7 @@ public class BaseTestConfiguration {
                                                                               InternalTaskCommandService internalTaskCommandService,
                                                                               TaskLinkManager taskLinkManager,
                                                                               CompletionService completionService,
+                                                                              TaskInterceptorProvider taskInterceptorProvider,
                                                                               Clock clock) {
         return new LocalTaskCommandServiceImpl(
             workerContextManager,
@@ -521,6 +532,7 @@ public class BaseTestConfiguration {
             internalTaskCommandService,
             taskLinkManager,
             completionService,
+            taskInterceptorProvider,
             clock
         );
     }
@@ -568,7 +580,8 @@ public class BaseTestConfiguration {
                                                          CommonSettings commonSettings,
                                                          TaskLinkManager taskLinkManager,
                                                          DistributedTaskMetricHelper distributedTaskMetricHelper,
-                                                         Clock clock) {
+                                                         Clock clock,
+                                                         TaskInterceptorProvider taskInterceptorProvider) {
         return new LocalAtLeastOnceWorker(
             clusterProvider,
             workerContextManager,
@@ -583,7 +596,8 @@ public class BaseTestConfiguration {
             commonSettings,
             taskLinkManager,
             distributedTaskMetricHelper,
-            clock
+            clock,
+            taskInterceptorProvider
         );
     }
 
@@ -602,7 +616,8 @@ public class BaseTestConfiguration {
                                                          CommonSettings commonSettings,
                                                          TaskLinkManager taskLinkManager,
                                                          DistributedTaskMetricHelper distributedTaskMetricHelper,
-                                                         Clock clock) {
+                                                         Clock clock,
+                                                         TaskInterceptorProvider taskInterceptorProvider) {
         return new LocalExactlyOnceWorker(
             clusterProvider,
             workerContextManager,
@@ -617,7 +632,8 @@ public class BaseTestConfiguration {
             commonSettings,
             taskLinkManager,
             distributedTaskMetricHelper,
-            clock
+            clock,
+            taskInterceptorProvider
         );
     }
 

--- a/core/distributed-task-library/src/test/java/com/distributed_task_framework/model/MetadataTest.java
+++ b/core/distributed-task-library/src/test/java/com/distributed_task_framework/model/MetadataTest.java
@@ -1,0 +1,206 @@
+package com.distributed_task_framework.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MetadataTest {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void shouldProvideBasicAccessors() {
+        //when
+        Metadata metadata = Metadata.from(Map.of(
+            "traceId", List.of("a", "b"),
+            "tenant", List.of("t")
+        ));
+
+        //verify
+        assertThat(metadata.isEmpty()).isFalse();
+        assertThat(metadata.size()).isEqualTo(2);
+        assertThat(metadata.containsKey("traceId")).isTrue();
+        assertThat(metadata.containsKey("absent")).isFalse();
+        assertThat(metadata.get("traceId")).containsExactly("a", "b");
+        assertThat(metadata.get("absent")).isEmpty();
+        assertThat(metadata.containsValue("traceId", "a")).isTrue();
+        assertThat(metadata.containsValue("traceId", "z")).isFalse();
+        assertThat(metadata.asMap()).containsOnlyKeys("traceId", "tenant");
+    }
+
+    @Test
+    void shouldProvideSingleValueAccessors() {
+        //when
+        Metadata metadata = Metadata.of("traceId", "a").add("traceId", "b");
+
+        //verify
+        assertThat(metadata.getSingle("traceId")).contains("a");
+        assertThat(metadata.getSingle("absent")).isEmpty();
+        assertThat(metadata.getSingleOrThrow("traceId")).isEqualTo("a");
+        assertThatThrownBy(() -> metadata.getSingleOrThrow("absent"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldDeepCopyOnCreation() {
+        //when
+        Map<String, List<String>> source = new HashMap<>();
+        source.put("key", new ArrayList<>(List.of("a")));
+
+        Metadata metadata = Metadata.from(source);
+        source.get("key").add("b");
+        source.put("other", List.of("c"));
+
+        //verify
+        assertThat(metadata.get("key")).containsExactly("a");
+        assertThat(metadata.containsKey("other")).isFalse();
+    }
+
+    @Test
+    void shouldBeImmutable() {
+        //when
+        Metadata metadata = Metadata.of("key", "a");
+
+        //verify
+        assertThatThrownBy(() -> metadata.asMap().put("k", List.of("v")))
+            .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> metadata.get("key").add("b"))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldRejectNullArguments() {
+        //when
+        Metadata metadata = Metadata.of("k", "v");
+
+        //verify
+        assertThatThrownBy(() -> Metadata.from(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Metadata.of(null, "v"))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Metadata.of("k", null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> metadata.get(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> metadata.getSingle(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> metadata.containsValue("k", null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> metadata.add(null, "v"))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> metadata.add("k", (String) null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> metadata.addAll("k", null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> metadata.with("k", (String) null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> metadata.with("k", (Collection<String>) null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> metadata.withIfAbsent("k", null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> metadata.remove(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> metadata.removeAll(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> metadata.putAll(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldAddAndKeepOriginalUntouched() {
+        //when
+        Metadata original = Metadata.of("traceId", "a");
+
+        Metadata updated = original
+            .add("traceId", "b")
+            .add("tenant", "t1", "t2")
+            .addAll("traceId", List.of("c"));
+
+        //verify
+        assertThat(original.get("traceId")).containsExactly("a");
+        assertThat(updated.get("traceId")).containsExactly("a", "b", "c");
+        assertThat(updated.get("tenant")).containsExactly("t1", "t2");
+    }
+
+    @Test
+    void shouldReplaceValuesWithWith() {
+        //when
+        Metadata metadata = Metadata.of("traceId", "a").add("traceId", "b");
+
+        Metadata updated = metadata
+            .with("traceId", "z")
+            .with("tenant", List.of("t1", "t2"));
+
+        //verify
+        assertThat(metadata.get("traceId")).containsExactly("a", "b");
+        assertThat(updated.get("traceId")).containsExactly("z");
+        assertThat(updated.get("tenant")).containsExactly("t1", "t2");
+    }
+
+    @Test
+    void shouldPutIfAbsent() {
+        //when
+        Metadata metadata = Metadata.of("traceId", "a");
+
+        Metadata unchanged = metadata.withIfAbsent("traceId", "z");
+        Metadata added = metadata.withIfAbsent("tenant", "t");
+
+        //verify
+        assertThat(unchanged).isSameAs(metadata);
+        assertThat(added.get("tenant")).containsExactly("t");
+    }
+
+    @Test
+    void shouldRemoveKeys() {
+        //when
+        Metadata metadata = Metadata.from(Map.of(
+            "a", List.of("1"),
+            "b", List.of("2"),
+            "c", List.of("3")
+        ));
+
+        Metadata updated = metadata
+            .remove("a")
+            .removeAll(List.of("b", "absent"));
+
+        //verify
+        assertThat(updated.asMap()).containsOnlyKeys("c");
+        assertThat(metadata.size()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldPutAllAppendingValues() {
+        //when
+        Metadata metadata = Metadata.of("a", "1");
+
+        Metadata updated = metadata.putAll(Map.of(
+            "a", List.of("2"),
+            "b", List.of("3")
+        ));
+
+        //verify
+        assertThat(updated.get("a")).containsExactly("1", "2");
+        assertThat(updated.get("b")).containsExactly("3");
+    }
+
+    @Test
+    void shouldSerializeToPlainMapJsonAndBack() throws Exception {
+        //when
+        Metadata metadata = Metadata.of("traceId", "a").add("traceId", "b").add("tenant", "t");
+
+        //do
+        String json = objectMapper.writeValueAsString(metadata);
+        Metadata deserialized = objectMapper.readValue(json, Metadata.class);
+
+        //verify
+        assertThat(json).isEqualTo("{\"traceId\":[\"a\",\"b\"],\"tenant\":[\"t\"]}");
+        assertThat(deserialized).isEqualTo(metadata);
+    }
+}

--- a/core/distributed-task-library/src/test/java/com/distributed_task_framework/service/impl/MetadataIntegrationTest.java
+++ b/core/distributed-task-library/src/test/java/com/distributed_task_framework/service/impl/MetadataIntegrationTest.java
@@ -1,0 +1,515 @@
+package com.distributed_task_framework.service.impl;
+
+import com.distributed_task_framework.BaseSpringIntegrationTest;
+import com.distributed_task_framework.interceptor.CommonTaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.CommonTaskExecutionInterceptor;
+import com.distributed_task_framework.interceptor.TaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.TaskExecutionChain;
+import com.distributed_task_framework.interceptor.TaskExecutionInterceptor;
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.Metadata;
+import com.distributed_task_framework.model.RegisteredTask;
+import com.distributed_task_framework.model.TaskDef;
+import com.distributed_task_framework.model.TaskId;
+import com.distributed_task_framework.persistence.entity.DltEntity;
+import com.distributed_task_framework.persistence.entity.TaskEntity;
+import com.distributed_task_framework.service.DistributedTaskService;
+import com.distributed_task_framework.service.internal.TaskRegistryService;
+import com.distributed_task_framework.service.internal.TaskWorker;
+import com.distributed_task_framework.service.internal.WorkerManager;
+import com.distributed_task_framework.settings.TaskSettings;
+import com.distributed_task_framework.task.TestStatefulTaskModelSpec;
+import com.distributed_task_framework.task.TestTaskModelSpec;
+import com.distributed_task_framework.utils.TaskGenerator;
+import com.google.common.collect.Lists;
+import lombok.AccessLevel;
+import lombok.SneakyThrows;
+import lombok.experimental.FieldDefaults;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Import(MetadataIntegrationTest.InterceptorsTestConfiguration.class)
+class MetadataIntegrationTest extends BaseSpringIntegrationTest {
+    static final ConcurrentLinkedQueue<String> EXECUTION_SEQUENCE = new ConcurrentLinkedQueue<>();
+    static final ConcurrentLinkedQueue<String> COMMON_EXECUTION_SEQUENCE = new ConcurrentLinkedQueue<>();
+
+    //turn off background workers and registry
+    @MockBean
+    WorkerManager workerManager;
+    @MockBean
+    TaskRegistryService taskRegistryService;
+
+    @Autowired
+    @Qualifier("localAtLeastOnceWorker")
+    TaskWorker taskWorker;
+    @Autowired
+    DistributedTaskService distributedTaskService;
+
+    @BeforeEach
+    public void init() {
+        super.init();
+        RecordingCreationInterceptor.INVOCATIONS.clear();
+        RecordingCreationInterceptorTwo.INVOCATIONS.clear();
+        CommonRecordingCreationInterceptor.INVOCATIONS.clear();
+        CommonRecordingCreationInterceptorTwo.INVOCATIONS.clear();
+        COMMON_EXECUTION_SEQUENCE.clear();
+        EXECUTION_SEQUENCE.clear();
+    }
+
+    @TestConfiguration
+    public static class InterceptorsTestConfiguration {
+
+        @Bean
+        public RecordingCreationInterceptor recordingCreationInterceptor() {
+            return new RecordingCreationInterceptor();
+        }
+
+        @Bean
+        public RecordingCreationInterceptorTwo recordingCreationInterceptorTwo() {
+            return new RecordingCreationInterceptorTwo();
+        }
+
+        @Bean
+        public FirstOrderedExecutionInterceptor firstOrderedExecutionInterceptor() {
+            return new FirstOrderedExecutionInterceptor();
+        }
+
+        @Bean
+        public SecondOrderedExecutionInterceptor secondOrderedExecutionInterceptor() {
+            return new SecondOrderedExecutionInterceptor();
+        }
+
+        @Bean
+        public CommonRecordingCreationInterceptor commonRecordingCreationInterceptor() {
+            return new CommonRecordingCreationInterceptor();
+        }
+
+        @Bean
+        public CommonRecordingCreationInterceptorTwo commonRecordingCreationInterceptorTwo() {
+            return new CommonRecordingCreationInterceptorTwo();
+        }
+
+        @Bean
+        public CommonRecordingExecutionInterceptor commonRecordingExecutionInterceptor() {
+            return new CommonRecordingExecutionInterceptor();
+        }
+    }
+
+    public record CreationInvocation(ExecutionContext<?> executionContext, TaskDef<?> taskDef) {
+    }
+
+    public static class RecordingCreationInterceptor implements TaskCreationInterceptor {
+        public static final ConcurrentLinkedQueue<CreationInvocation> INVOCATIONS = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+            INVOCATIONS.add(new CreationInvocation(executionContext, taskDef));
+            return executionContext.withMetadata(executionContext.getMetadata().add("createdBy", "interceptor"));
+        }
+    }
+
+    public static class RecordingCreationInterceptorTwo implements TaskCreationInterceptor {
+        public static final ConcurrentLinkedQueue<CreationInvocation> INVOCATIONS = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+            INVOCATIONS.add(new CreationInvocation(executionContext, taskDef));
+            return executionContext;
+        }
+    }
+
+    public static class CommonRecordingCreationInterceptor implements CommonTaskCreationInterceptor {
+        public static final ConcurrentLinkedQueue<CreationInvocation> INVOCATIONS = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+            INVOCATIONS.add(new CreationInvocation(executionContext, taskDef));
+            return executionContext;
+        }
+    }
+
+    public static class CommonRecordingCreationInterceptorTwo implements CommonTaskCreationInterceptor {
+        public static final ConcurrentLinkedQueue<CreationInvocation> INVOCATIONS = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+            INVOCATIONS.add(new CreationInvocation(executionContext, taskDef));
+            return executionContext;
+        }
+    }
+
+    public static class CommonRecordingExecutionInterceptor implements CommonTaskExecutionInterceptor {
+        @Override
+        public <U> void execute(ExecutionContext<U> executionContext, TaskDef<U> taskDef, TaskExecutionChain chain) throws Exception {
+            COMMON_EXECUTION_SEQUENCE.add("before-common");
+            chain.proceed();
+            COMMON_EXECUTION_SEQUENCE.add("after-common");
+        }
+    }
+
+    @Order(1)
+    public static class FirstOrderedExecutionInterceptor implements TaskExecutionInterceptor {
+        @Override
+        public <U> void execute(ExecutionContext<U> executionContext, TaskDef<U> taskDef, TaskExecutionChain chain) throws Exception {
+            EXECUTION_SEQUENCE.add("before-first");
+            chain.proceed();
+            EXECUTION_SEQUENCE.add("after-first");
+        }
+    }
+
+    @Order(2)
+    public static class SecondOrderedExecutionInterceptor implements TaskExecutionInterceptor {
+        @Override
+        public <U> void execute(ExecutionContext<U> executionContext, TaskDef<U> taskDef, TaskExecutionChain chain) throws Exception {
+            EXECUTION_SEQUENCE.add("before-second");
+            chain.proceed();
+            EXECUTION_SEQUENCE.add("after-second");
+        }
+    }
+
+    @SneakyThrows
+    @Test
+    void shouldProvideApiMetadataAtExecution() {
+        //when
+        ConcurrentLinkedQueue<ExecutionContext<String>> executedContexts = new ConcurrentLinkedQueue<>();
+        var taskModel = extendedTaskGenerator.generate(TestTaskModelSpec.builder(String.class)
+            .action(executedContexts::add)
+            .build()
+        );
+        Metadata metadata = Metadata.of("traceId", "abc-123");
+
+        //do
+        TaskId taskId = distributedTaskService.schedule(
+            taskModel.getTaskDef(),
+            executionContext("hello", metadata)
+        );
+
+        //verify persistence
+        TaskEntity taskEntity = taskRepository.find(taskId.getId()).orElseThrow();
+        assertThat(readPersistedMetadata(taskEntity)).isEqualTo(metadata);
+
+        //do execution
+        taskWorker.execute(taskEntity, taskModel.getRegisteredTask());
+
+        //verify
+        assertThat(executedContexts).singleElement().satisfies(ctx ->
+            assertThat(ctx.getMetadata()).isEqualTo(metadata)
+        );
+    }
+
+    @SneakyThrows
+    @Test
+    void shouldApplyCreationInterceptorMetadata() {
+        //when
+        ConcurrentLinkedQueue<ExecutionContext<String>> executedContexts = new ConcurrentLinkedQueue<>();
+        var taskModel = extendedTaskGenerator.generate(TestTaskModelSpec.builder(String.class)
+            .action(executedContexts::add)
+            .taskSetting(settings -> settings.toBuilder()
+                .creationInterceptors(List.of(RecordingCreationInterceptor.class))
+                .build())
+            .build()
+        );
+
+        //do
+        TaskId taskId = distributedTaskService.schedule(taskModel.getTaskDef(), executionContext("hello", Metadata.empty()));
+
+        //verify interceptor has been invoked with the task definition in scope
+        assertThat(RecordingCreationInterceptor.INVOCATIONS).singleElement().satisfies(invocation ->
+            assertThat(invocation.taskDef()).isEqualTo(taskModel.getTaskDef())
+        );
+
+        //verify metadata added by the interceptor has been persisted
+        TaskEntity taskEntity = taskRepository.find(taskId.getId()).orElseThrow();
+        assertThat(readPersistedMetadata(taskEntity).get("createdBy")).isEqualTo(List.of("interceptor"));
+
+        //do execution
+        taskWorker.execute(taskEntity, taskModel.getRegisteredTask());
+
+        //verify metadata is available at execution
+        assertThat(executedContexts).singleElement().satisfies(ctx ->
+            assertThat(ctx.getMetadata().get("createdBy")).isEqualTo(List.of("interceptor"))
+        );
+    }
+
+    @SneakyThrows
+    @Test
+    void shouldNotApplyCreationInterceptorsWhenNotSelected() {
+        //when
+        var taskModel = extendedTaskGenerator.generate(TestTaskModelSpec.builder(String.class)
+            .action(ctx -> {
+            })
+            .build()
+        );
+
+        //do
+        TaskId taskId = distributedTaskService.schedule(taskModel.getTaskDef(), executionContext("hello", Metadata.empty()));
+
+        //verify
+        assertThat(RecordingCreationInterceptor.INVOCATIONS).isEmpty();
+        assertThat(RecordingCreationInterceptorTwo.INVOCATIONS).isEmpty();
+        TaskEntity taskEntity = taskRepository.find(taskId.getId()).orElseThrow();
+        assertThat(taskEntity.getMetadataBytes()).isNull();
+    }
+
+    @SneakyThrows
+    @Test
+    void shouldWrapExecutionWithInterceptorsInOrder() {
+        //when
+        var taskModel = extendedTaskGenerator.generate(TestTaskModelSpec.builder(String.class)
+            .action(ctx -> EXECUTION_SEQUENCE.add("task"))
+            .taskSetting(settings -> settings.toBuilder()
+                .executionInterceptors(List.of(
+                    FirstOrderedExecutionInterceptor.class,
+                    SecondOrderedExecutionInterceptor.class
+                ))
+                .build())
+            .build()
+        );
+        TaskId taskId = distributedTaskService.schedule(taskModel.getTaskDef(), executionContext("hello", Metadata.empty()));
+        TaskEntity taskEntity = taskRepository.find(taskId.getId()).orElseThrow();
+
+        //do
+        taskWorker.execute(taskEntity, taskModel.getRegisteredTask());
+
+        //verify
+        assertThat(EXECUTION_SEQUENCE).containsExactly(
+            "before-first",
+            "before-second",
+            "task",
+            "after-second",
+            "after-first"
+        );
+    }
+
+    @SneakyThrows
+    @Test
+    void shouldWrapStatefulTaskExecutionWithInterceptors() {
+        //when
+        ConcurrentLinkedQueue<Metadata> capturedMetadata = new ConcurrentLinkedQueue<>();
+        var statefulTaskModel = extendedTaskGenerator.generate(TestStatefulTaskModelSpec.builder(String.class, String.class)
+            .action((ctx, holder) -> capturedMetadata.add(ctx.getMetadata()))
+            .taskSetting(settings -> settings.toBuilder()
+                .executionInterceptors(List.of(FirstOrderedExecutionInterceptor.class))
+                .build())
+            .build()
+        );
+        Metadata metadata = Metadata.of("traceId", "stateful-1");
+        TaskId taskId = distributedTaskService.schedule(
+            statefulTaskModel.getTaskDef(),
+            executionContext("hello", metadata)
+        );
+        TaskEntity taskEntity = taskRepository.find(taskId.getId()).orElseThrow();
+
+        //do
+        taskWorker.execute(taskEntity, statefulTaskModel.getRegisteredTask());
+
+        //verify
+        assertThat(capturedMetadata).singleElement().isEqualTo(metadata);
+        assertThat(EXECUTION_SEQUENCE).containsExactly("before-first", "after-first");
+    }
+
+    @SneakyThrows
+    @Test
+    void shouldInheritMetadataToChildTask() {
+        //when
+        ConcurrentLinkedQueue<ExecutionContext<String>> childContexts = new ConcurrentLinkedQueue<>();
+        var childTaskModel = extendedTaskGenerator.generate(TestTaskModelSpec.builder(String.class)
+            .action(childContexts::add)
+            .build()
+        );
+        TaskDef<String> taskDef = childTaskModel.getTaskDef();
+        AtomicReference<TaskId> childTaskIdRef = new AtomicReference<>();
+        var parentTaskModel = extendedTaskGenerator.generate(TestTaskModelSpec.builder(taskDef)
+            .action(ctx -> childTaskIdRef.set(distributedTaskService.schedule(taskDef, ctx.withNewMessage("child"))))
+            .build()
+        );
+        Metadata metadata = Metadata.of("traceId", "flow-1");
+
+        //do
+        TaskId parentTaskId = distributedTaskService.schedule(taskDef, executionContext("parent", metadata));
+        TaskEntity parentTaskEntity = taskRepository.find(parentTaskId.getId()).orElseThrow();
+        taskWorker.execute(parentTaskEntity, parentTaskModel.getRegisteredTask());
+
+        //verify child has been created and inherits metadata
+        TaskEntity childTaskEntity = taskRepository.find(childTaskIdRef.get().getId()).orElseThrow();
+        assertThat(readPersistedMetadata(childTaskEntity)).isEqualTo(metadata);
+        taskWorker.execute(childTaskEntity, childTaskModel.getRegisteredTask());
+        assertThat(childContexts).singleElement().satisfies(ctx ->
+            assertThat(ctx.getMetadata()).isEqualTo(metadata)
+        );
+    }
+
+    @SneakyThrows
+    @Test
+    void shouldKeepMetadataOnRetry() {
+        //when
+        AtomicInteger attempts = new AtomicInteger();
+        ConcurrentLinkedQueue<Metadata> capturedMetadata = new ConcurrentLinkedQueue<>();
+        var taskModel = extendedTaskGenerator.generate(TestTaskModelSpec.builder(String.class)
+            .action(ctx -> {
+                capturedMetadata.add(ctx.getMetadata());
+                if (attempts.getAndIncrement() == 0) {
+                    throw new RuntimeException("first attempt fails");
+                }
+            })
+            .build()
+        );
+        Metadata metadata = Metadata.of("traceId", "retry-1");
+        TaskId taskId = distributedTaskService.schedule(taskModel.getTaskDef(), executionContext("hello", metadata));
+        TaskEntity taskEntity = taskRepository.find(taskId.getId()).orElseThrow();
+
+        //do
+        taskWorker.execute(taskEntity, taskModel.getRegisteredTask());
+        TaskEntity retriedTaskEntity = taskRepository.find(taskId.getId()).orElseThrow();
+        assertThat(retriedTaskEntity.getFailures()).isEqualTo(1);
+        taskWorker.execute(retriedTaskEntity, taskModel.getRegisteredTask());
+
+        //verify metadata is the same on both attempts
+        assertThat(capturedMetadata).containsExactly(metadata, metadata);
+    }
+
+    @SneakyThrows
+    @Test
+    void shouldCopyMetadataToDlt() {
+        //when
+        var taskModel = extendedTaskGenerator.generate(TestTaskModelSpec.builder(String.class)
+            .action(ctx -> {
+                throw new RuntimeException("permanent fail");
+            })
+            .failureAction(ctx -> true)
+            .build()
+        );
+        Metadata metadata = Metadata.of("traceId", "dlt-1");
+        TaskId taskId = distributedTaskService.schedule(taskModel.getTaskDef(), executionContext("hello", metadata));
+        TaskEntity taskEntity = taskRepository.find(taskId.getId()).orElseThrow();
+
+        //do
+        taskWorker.execute(taskEntity, taskModel.getRegisteredTask());
+
+        //verify
+        DltEntity dltEntity = waitAndGet(
+            () -> Lists.newArrayList(dltRepository.findAll()),
+            dltEntities -> !dltEntities.isEmpty()
+        ).get(0);
+        assertThat(readPersistedMetadata(dltEntity)).isEqualTo(metadata);
+    }
+
+    @SneakyThrows
+    @Test
+    void shouldApplyCommonInterceptorsWithoutConfig() {
+        //when
+        var taskModel = extendedTaskGenerator.generate(TestTaskModelSpec.builder(String.class)
+            .action(ctx -> {
+            })
+            .build()
+        );
+        TaskId taskId = distributedTaskService.schedule(taskModel.getTaskDef(), executionContext("hello", Metadata.empty()));
+        TaskEntity taskEntity = taskRepository.find(taskId.getId()).orElseThrow();
+
+        //do
+        taskWorker.execute(taskEntity, taskModel.getRegisteredTask());
+
+        //verify common interceptors have been applied without any config
+        assertThat(CommonRecordingCreationInterceptor.INVOCATIONS).singleElement().satisfies(invocation ->
+            assertThat(invocation.taskDef()).isEqualTo(taskModel.getTaskDef())
+        );
+        assertThat(COMMON_EXECUTION_SEQUENCE).containsExactly("before-common", "after-common");
+    }
+
+    @SneakyThrows
+    @Test
+    void shouldExcludeCommonInterceptorsPerTask() {
+        //when
+        var taskModel = extendedTaskGenerator.generate(TestTaskModelSpec.builder(String.class)
+            .action(ctx -> {
+            })
+            .taskSetting(settings -> settings.toBuilder()
+                .excludedCommonCreationInterceptors(List.of(CommonRecordingCreationInterceptor.class))
+                .excludedCommonExecutionInterceptors(List.of(CommonRecordingExecutionInterceptor.class))
+                .build())
+            .build()
+        );
+        TaskId taskId = distributedTaskService.schedule(taskModel.getTaskDef(), executionContext("hello", Metadata.empty()));
+        TaskEntity taskEntity = taskRepository.find(taskId.getId()).orElseThrow();
+
+        //do
+        taskWorker.execute(taskEntity, taskModel.getRegisteredTask());
+
+        //verify excluded common interceptors have not been applied, others have
+        assertThat(CommonRecordingCreationInterceptor.INVOCATIONS).isEmpty();
+        assertThat(CommonRecordingCreationInterceptorTwo.INVOCATIONS).hasSize(1);
+        assertThat(COMMON_EXECUTION_SEQUENCE).isEmpty();
+    }
+
+    @SneakyThrows
+    @Test
+    void shouldSkipCreationInterceptorsForClusterOnlyTask() {
+        //when
+        TaskDef<String> taskDef = TaskDef.privateTaskDef("cluster-only-task", String.class);
+        ConcurrentLinkedQueue<ExecutionContext<String>> executedContexts = new ConcurrentLinkedQueue<>();
+        TaskSettings taskSettings = defaultTaskSettings.toBuilder().build();
+        RegisteredTask<String> registeredTask = RegisteredTask.of(
+            TaskGenerator.defineTask(taskDef, executedContexts::add),
+            taskSettings
+        );
+        when(taskRegistryService.getRegisteredTask(taskDef)).thenReturn(Optional.empty());
+        when(taskRegistryService.hasClusterRegisteredTaskByName(taskDef.getTaskName())).thenReturn(true);
+        Metadata metadata = Metadata.of("traceId", "cluster-1");
+
+        //do
+        TaskId taskId = distributedTaskService.scheduleUnsafe(taskDef, executionContext("hello", metadata));
+
+        //verify configured creation interceptors have not been invoked but common ones have
+        assertThat(RecordingCreationInterceptor.INVOCATIONS).isEmpty();
+        assertThat(RecordingCreationInterceptorTwo.INVOCATIONS).isEmpty();
+        assertThat(CommonRecordingCreationInterceptor.INVOCATIONS).hasSize(1);
+        TaskEntity taskEntity = taskRepository.find(taskId.getId()).orElseThrow();
+        assertThat(readPersistedMetadata(taskEntity)).isEqualTo(metadata);
+
+        //do execution
+        taskWorker.execute(taskEntity, registeredTask);
+
+        //verify metadata is available at execution
+        assertThat(executedContexts).singleElement().satisfies(ctx ->
+            assertThat(ctx.getMetadata()).isEqualTo(metadata)
+        );
+    }
+
+    private ExecutionContext<String> executionContext(String message, Metadata metadata) {
+        return ExecutionContext.<String>builder()
+            .workflowId(UUID.randomUUID())
+            .inputMessage(message)
+            .metadata(metadata)
+            .build();
+    }
+
+    @SneakyThrows
+    private Metadata readPersistedMetadata(TaskEntity taskEntity) {
+        return taskSerializer.readValue(taskEntity.getMetadataBytes(), Metadata.class);
+    }
+
+    @SneakyThrows
+    private Metadata readPersistedMetadata(DltEntity dltEntity) {
+        return taskSerializer.readValue(dltEntity.getMetadataBytes(), Metadata.class);
+    }
+}

--- a/core/distributed-task-library/src/test/java/com/distributed_task_framework/service/impl/TaskInterceptorProviderImplTest.java
+++ b/core/distributed-task-library/src/test/java/com/distributed_task_framework/service/impl/TaskInterceptorProviderImplTest.java
@@ -1,0 +1,240 @@
+package com.distributed_task_framework.service.impl;
+
+import com.distributed_task_framework.exception.TaskConfigurationException;
+import com.distributed_task_framework.interceptor.CommonTaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.CommonTaskExecutionInterceptor;
+import com.distributed_task_framework.interceptor.TaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.TaskExecutionChain;
+import com.distributed_task_framework.interceptor.TaskExecutionInterceptor;
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.TaskDef;
+import com.distributed_task_framework.settings.TaskSettings;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TaskInterceptorProviderImplTest {
+
+    interface UnknownCreationInterceptor extends TaskCreationInterceptor {
+    }
+
+    static class CreationFirst implements TaskCreationInterceptor {
+        @Override
+        public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+            return executionContext;
+        }
+    }
+
+    static class CommonCreationFirst implements CommonTaskCreationInterceptor {
+        @Override
+        public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+            return executionContext;
+        }
+    }
+
+    static class CommonCreationSecond implements CommonTaskCreationInterceptor {
+        @Override
+        public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+            return executionContext;
+        }
+    }
+
+    static class CommonExecutionFirst implements CommonTaskExecutionInterceptor {
+        @Override
+        public <U> void execute(ExecutionContext<U> executionContext, TaskDef<U> taskDef, TaskExecutionChain chain) {
+        }
+    }
+
+    static class CreationSecond implements TaskCreationInterceptor {
+        @Override
+        public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+            return executionContext;
+        }
+    }
+
+    @Order(1)
+    static class CreationOrdered implements TaskCreationInterceptor {
+        @Override
+        public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+            return executionContext;
+        }
+    }
+
+    static class ExecutionFirst implements TaskExecutionInterceptor {
+        @Override
+        public <U> void execute(ExecutionContext<U> executionContext, TaskDef<U> taskDef, TaskExecutionChain chain) {
+        }
+    }
+
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    static class ExecutionOrdered implements TaskExecutionInterceptor {
+        @Override
+        public <U> void execute(ExecutionContext<U> executionContext, TaskDef<U> taskDef, TaskExecutionChain chain) {
+        }
+    }
+
+    @Test
+    void shouldResolveInterceptorsByClass() {
+        //when
+        TaskInterceptorProviderImpl provider = new TaskInterceptorProviderImpl(
+            List.of(new CreationFirst(), new CreationSecond()),
+            List.of(new ExecutionFirst())
+        );
+
+        //do
+        List<TaskCreationInterceptor> creation = provider.getCreationInterceptors(TaskSettings.builder()
+            .creationInterceptors(List.of(CreationSecond.class))
+            .build()
+        );
+        List<TaskExecutionInterceptor> execution = provider.getExecutionInterceptors(TaskSettings.builder()
+            .executionInterceptors(List.of(ExecutionFirst.class))
+            .build()
+        );
+
+        //verify
+        assertThat(creation).hasSize(1).first().isInstanceOf(CreationSecond.class);
+        assertThat(execution).hasSize(1).first().isInstanceOf(ExecutionFirst.class);
+    }
+
+    @Test
+    void shouldResolveInterceptorsByBaseClass() {
+        //when
+        TaskInterceptorProviderImpl provider = new TaskInterceptorProviderImpl(
+            List.of(new CreationFirst()),
+            List.of(new ExecutionFirst())
+        );
+
+        //do
+        List<TaskCreationInterceptor> creation = provider.getCreationInterceptors(TaskSettings.builder()
+            .creationInterceptors(List.of(TaskCreationInterceptor.class))
+            .build()
+        );
+
+        //verify
+        assertThat(creation).hasSize(1).first().isInstanceOf(CreationFirst.class);
+    }
+
+    @Test
+    void shouldFailFastWhenConfiguredInterceptorIsNotRegistered() {
+        //when
+        TaskInterceptorProviderImpl provider = new TaskInterceptorProviderImpl(
+            List.of(new CreationFirst()),
+            List.of()
+        );
+
+        //do/verify
+        assertThatThrownBy(() -> provider.getCreationInterceptors(TaskSettings.builder()
+            .creationInterceptors(List.of(UnknownCreationInterceptor.class))
+            .build()
+        ))
+            .isInstanceOf(TaskConfigurationException.class)
+            .hasMessageContaining(UnknownCreationInterceptor.class.getName())
+            .hasMessageContaining(CreationFirst.class.getName());
+    }
+
+    @Test
+    void shouldSortInterceptorsByOrder() {
+        //when
+        TaskInterceptorProviderImpl provider = new TaskInterceptorProviderImpl(
+            List.of(new CreationSecond(), new CreationFirst(), new CreationOrdered()),
+            List.of()
+        );
+
+        //do
+        List<TaskCreationInterceptor> creation = provider.getCreationInterceptors(TaskSettings.builder()
+            .creationInterceptors(List.of(
+                CreationFirst.class,
+                CreationOrdered.class,
+                CreationSecond.class
+            ))
+            .build()
+        );
+
+        //verify
+        assertThat(creation)
+            .extracting(Object::getClass)
+            .containsExactly(
+                CreationOrdered.class,
+                CreationFirst.class,
+                CreationSecond.class
+            );
+    }
+
+    @Test
+    void shouldReturnEmptyListForEmptyConfig() {
+        //when
+        TaskInterceptorProviderImpl provider = new TaskInterceptorProviderImpl(List.of(), List.of());
+
+        //do
+        List<TaskCreationInterceptor> creation = provider.getCreationInterceptors(TaskSettings.DEFAULT);
+        List<TaskExecutionInterceptor> execution = provider.getExecutionInterceptors(TaskSettings.DEFAULT);
+
+        //verify
+        assertThat(creation).isEmpty();
+        assertThat(execution).isEmpty();
+    }
+
+    @Test
+    void shouldApplyCommonInterceptorsWithoutConfig() {
+        //when
+        TaskInterceptorProviderImpl provider = new TaskInterceptorProviderImpl(
+            List.of(new CommonCreationFirst(), new CreationFirst()),
+            List.of(new CommonExecutionFirst())
+        );
+
+        //do
+        List<TaskCreationInterceptor> creation = provider.getCreationInterceptors(TaskSettings.DEFAULT);
+        List<TaskExecutionInterceptor> execution = provider.getExecutionInterceptors(TaskSettings.DEFAULT);
+
+        //verify
+        assertThat(creation)
+            .extracting(Object::getClass)
+            .containsExactly(CommonCreationFirst.class);
+        assertThat(execution)
+            .extracting(Object::getClass)
+            .containsExactly(CommonExecutionFirst.class);
+    }
+
+    @Test
+    void shouldExcludeCommonInterceptorsPerTask() {
+        //when
+        TaskInterceptorProviderImpl provider = new TaskInterceptorProviderImpl(
+            List.of(new CommonCreationFirst(), new CommonCreationSecond(), new CreationFirst()),
+            List.of()
+        );
+
+        //do
+        List<TaskCreationInterceptor> creation = provider.getCreationInterceptors(TaskSettings.builder()
+            .excludedCommonCreationInterceptors(List.of(CommonCreationFirst.class))
+            .build()
+        );
+
+        //verify
+        assertThat(creation)
+            .extracting(Object::getClass)
+            .containsExactly(CommonCreationSecond.class);
+    }
+
+    @Test
+    void shouldExcludeCommonInterceptorsByBaseClass() {
+        //when
+        TaskInterceptorProviderImpl provider = new TaskInterceptorProviderImpl(
+            List.of(new CommonCreationFirst(), new CommonCreationSecond()),
+            List.of()
+        );
+
+        //do
+        List<TaskCreationInterceptor> creation = provider.getCreationInterceptors(TaskSettings.builder()
+            .excludedCommonCreationInterceptors(List.of(CommonTaskCreationInterceptor.class))
+            .build()
+        );
+
+        //verify
+        assertThat(creation).isEmpty();
+    }
+}

--- a/core/distributed-task-spring-boot-autoconfigure/config-prop.md
+++ b/core/distributed-task-spring-boot-autoconfigure/config-prop.md
@@ -106,6 +106,10 @@ This is a document about the configuration properties in DTF autoconfiguration m
 | max-parallel-in-cluster| java.lang.Integer| How many parallel tasks can be in the cluster. &#x27;-1&#x27; means undefined and depends on current cluster configuration.| -1| | 
 | max-parallel-in-node| java.lang.Integer| How many parallel tasks can be on the one node (one worker). &#x27;-1&#x27; means undefined.| -1| | 
 | timeout| java.time.Duration| Task timeout. If task still is in progress after timeout expired, it will be interrupted. {@link InterruptedException} will be risen in {@link Task#execute(ExecutionContext)}| 0| | 
+| creation-interceptors| java.util.List&lt;java.lang.Class&lt;? extends com.distributed_task_framework.interceptor.TaskCreationInterceptor&gt;&gt;| Creation interceptors of the task, identified by classes. Combined with default-properties interceptors and deduplicated.| | | 
+| execution-interceptors| java.util.List&lt;java.lang.Class&lt;? extends com.distributed_task_framework.interceptor.TaskExecutionInterceptor&gt;&gt;| Execution interceptors of the task, identified by classes. Combined with default-properties interceptors and deduplicated.| | | 
+| excluded-common-creation-interceptors| java.util.List&lt;java.lang.Class&lt;? extends com.distributed_task_framework.interceptor.CommonTaskCreationInterceptor&gt;&gt;| Common creation interceptors excluded for the task, combined with default-properties and deduplicated.| | | 
+| excluded-common-execution-interceptors| java.util.List&lt;java.lang.Class&lt;? extends com.distributed_task_framework.interceptor.CommonTaskExecutionInterceptor&gt;&gt;| Common execution interceptors excluded for the task, combined with default-properties and deduplicated.| | | 
 ### distributed-task.common.completion
 **Class:** `com.distributed_task_framework.autoconfigure.DistributedTaskProperties$Completion`
 

--- a/core/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/DistributedTaskAutoconfigure.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/DistributedTaskAutoconfigure.java
@@ -4,6 +4,8 @@ import com.distributed_task_framework.autoconfigure.annotation.DtfDataSource;
 import com.distributed_task_framework.autoconfigure.mapper.CommonSettingsMerger;
 import com.distributed_task_framework.autoconfigure.mapper.DistributedTaskPropertiesMapper;
 import com.distributed_task_framework.autoconfigure.mapper.DistributedTaskPropertiesMerger;
+import com.distributed_task_framework.interceptor.TaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.TaskExecutionInterceptor;
 import com.distributed_task_framework.mapper.CommandMapper;
 import com.distributed_task_framework.mapper.NodeStateMapper;
 import com.distributed_task_framework.mapper.PartitionMapper;
@@ -29,6 +31,7 @@ import com.distributed_task_framework.persistence.repository.TaskLinkRepository;
 import com.distributed_task_framework.persistence.repository.TaskMessageRepository;
 import com.distributed_task_framework.persistence.repository.TaskRepository;
 import com.distributed_task_framework.service.DistributedTaskService;
+import com.distributed_task_framework.service.TaskInterceptorProvider;
 import com.distributed_task_framework.service.TaskSerializer;
 import com.distributed_task_framework.service.impl.ClusterProviderImpl;
 import com.distributed_task_framework.service.impl.CompletionServiceImpl;
@@ -39,6 +42,7 @@ import com.distributed_task_framework.service.impl.InternalTaskCommandServiceImp
 import com.distributed_task_framework.service.impl.JoinTaskPlannerImpl;
 import com.distributed_task_framework.service.impl.JoinTaskStatHelper;
 import com.distributed_task_framework.service.impl.JsonTaskSerializerImpl;
+import com.distributed_task_framework.service.impl.TaskInterceptorProviderImpl;
 import com.distributed_task_framework.service.impl.LocalTaskCommandServiceImpl;
 import com.distributed_task_framework.service.impl.DistributedTaskMetricHelperImpl;
 import com.distributed_task_framework.service.impl.PartitionTrackerImpl;
@@ -607,6 +611,13 @@ public class DistributedTaskAutoconfigure {
 
     @Bean
     @ConditionalOnMissingBean
+    public TaskInterceptorProvider taskInterceptorProvider(List<TaskCreationInterceptor> taskCreationInterceptors,
+                                                           List<TaskExecutionInterceptor> taskExecutionInterceptors) {
+        return new TaskInterceptorProviderImpl(taskCreationInterceptors, taskExecutionInterceptors);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
     public TaskCommandWithDetectorService localTaskCommandWithDetectorService(WorkerContextManager workerContextManager,
                                                                               @Qualifier(DTF_TX_MANAGER) PlatformTransactionManager transactionManager,
                                                                               TaskRepository taskRepository,
@@ -618,6 +629,7 @@ public class DistributedTaskAutoconfigure {
                                                                               TaskLinkManager taskLinkManager,
                                                                               InternalTaskCommandService internalTaskCommandService,
                                                                               CompletionService completionService,
+                                                                              TaskInterceptorProvider taskInterceptorProvider,
                                                                               Clock clock) {
         return new LocalTaskCommandServiceImpl(
             workerContextManager,
@@ -631,6 +643,7 @@ public class DistributedTaskAutoconfigure {
             internalTaskCommandService,
             taskLinkManager,
             completionService,
+            taskInterceptorProvider,
             clock
         );
     }
@@ -707,7 +720,8 @@ public class DistributedTaskAutoconfigure {
                                                          CommonSettings commonSettings,
                                                          TaskLinkManager taskLinkManager,
                                                          DistributedTaskMetricHelper distributedTaskMetricHelper,
-                                                         Clock clock) {
+                                                         Clock clock,
+                                                         TaskInterceptorProvider taskInterceptorProvider) {
         return new LocalAtLeastOnceWorker(
             clusterProvider,
             workerContextManager,
@@ -722,7 +736,8 @@ public class DistributedTaskAutoconfigure {
             commonSettings,
             taskLinkManager,
             distributedTaskMetricHelper,
-            clock
+            clock,
+            taskInterceptorProvider
         );
     }
 
@@ -741,7 +756,8 @@ public class DistributedTaskAutoconfigure {
                                                          CommonSettings commonSettings,
                                                          TaskLinkManager taskLinkManager,
                                                          DistributedTaskMetricHelper distributedTaskMetricHelper,
-                                                         Clock clock) {
+                                                         Clock clock,
+                                                         TaskInterceptorProvider taskInterceptorProvider) {
         return new LocalExactlyOnceWorker(
             clusterProvider,
             workerContextManager,
@@ -756,7 +772,8 @@ public class DistributedTaskAutoconfigure {
             commonSettings,
             taskLinkManager,
             distributedTaskMetricHelper,
-            clock
+            clock,
+            taskInterceptorProvider
         );
     }
 

--- a/core/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/DistributedTaskProperties.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/DistributedTaskProperties.java
@@ -1,5 +1,9 @@
 package com.distributed_task_framework.autoconfigure;
 
+import com.distributed_task_framework.interceptor.CommonTaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.CommonTaskExecutionInterceptor;
+import com.distributed_task_framework.interceptor.TaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.TaskExecutionInterceptor;
 import com.distributed_task_framework.model.ExecutionContext;
 import com.distributed_task_framework.task.Task;
 import com.google.common.collect.Maps;
@@ -15,6 +19,7 @@ import org.springframework.validation.annotation.Validated;
 
 import java.net.URL;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 
 @Validated
@@ -283,6 +288,24 @@ public class DistributedTaskProperties {
          * {@link InterruptedException} will be risen in {@link Task#execute(ExecutionContext)}
          */
         Duration timeout; // @TaskTimeout
+        /**
+         * Creation interceptors of the task, combined with default-properties and deduplicated.
+         */
+        List<Class<? extends TaskCreationInterceptor>> creationInterceptors; // @TaskCreationInterceptors
+        /**
+         * Execution interceptors of the task, combined with default-properties and deduplicated.
+         */
+        List<Class<? extends TaskExecutionInterceptor>> executionInterceptors; // @TaskExecutionInterceptors
+        /**
+         * Common creation interceptors excluded for the task, composed of annotations and yaml per-task, deduplicated.
+         * It is prohibited to set exclusions in default-properties.
+         */
+        List<Class<? extends CommonTaskCreationInterceptor>> excludedCommonCreationInterceptors; // @TaskCreationInterceptors
+        /**
+         * Common execution interceptors excluded for the task, composed of annotations and yaml per-task, deduplicated.
+         * It is prohibited to set exclusions in default-properties.
+         */
+        List<Class<? extends CommonTaskExecutionInterceptor>> excludedCommonExecutionInterceptors; // @TaskExecutionInterceptors
     }
 
     @Data

--- a/core/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/TaskConfigurationDiscoveryProcessor.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/TaskConfigurationDiscoveryProcessor.java
@@ -3,14 +3,20 @@ package com.distributed_task_framework.autoconfigure;
 import com.distributed_task_framework.autoconfigure.annotation.RetryOff;
 import com.distributed_task_framework.autoconfigure.annotation.TaskBackoffRetryPolicy;
 import com.distributed_task_framework.autoconfigure.annotation.TaskConcurrency;
+import com.distributed_task_framework.autoconfigure.annotation.TaskCreationInterceptors;
 import com.distributed_task_framework.autoconfigure.annotation.TaskDltEnable;
 import com.distributed_task_framework.autoconfigure.annotation.TaskExecutionGuarantees;
+import com.distributed_task_framework.autoconfigure.annotation.TaskExecutionInterceptors;
 import com.distributed_task_framework.autoconfigure.annotation.TaskFixedRetryPolicy;
 import com.distributed_task_framework.autoconfigure.annotation.TaskSchedule;
 import com.distributed_task_framework.autoconfigure.annotation.TaskTimeout;
 import com.distributed_task_framework.autoconfigure.mapper.DistributedTaskPropertiesMapper;
 import com.distributed_task_framework.autoconfigure.mapper.DistributedTaskPropertiesMerger;
 import com.distributed_task_framework.exception.TaskConfigurationException;
+import com.distributed_task_framework.interceptor.CommonTaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.CommonTaskExecutionInterceptor;
+import com.distributed_task_framework.interceptor.TaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.TaskExecutionInterceptor;
 import com.distributed_task_framework.model.ExecutionContext;
 import com.distributed_task_framework.model.TaskDef;
 import com.distributed_task_framework.service.DistributedTaskService;
@@ -30,12 +36,15 @@ import org.springframework.util.StringUtils;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
+import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -79,9 +88,33 @@ public class TaskConfigurationDiscoveryProcessor {
     @SneakyThrows
     @PostConstruct
     public void init() {
+        validateDefaultProperties();
         registerLocalTasks();
         registerRemoteTasksFromCode();
         //configurations for unknown local tasks just ignore.
+    }
+
+    private void validateDefaultProperties() {
+        var defaultProperties = Optional.ofNullable(properties.getTaskPropertiesGroup())
+            .map(DistributedTaskProperties.TaskPropertiesGroup::getDefaultProperties)
+            .orElse(null);
+        if (defaultProperties == null) {
+            return;
+        }
+        var excludedCommonCreation = defaultProperties.getExcludedCommonCreationInterceptors();
+        if (excludedCommonCreation != null && !excludedCommonCreation.isEmpty()) {
+            throw new TaskConfigurationException(
+                "It is prohibited to exclude common interceptors in default-properties, " +
+                    "excluded-common-creation-interceptors=[%s]".formatted(excludedCommonCreation)
+            );
+        }
+        var excludedCommonExecution = defaultProperties.getExcludedCommonExecutionInterceptors();
+        if (excludedCommonExecution != null && !excludedCommonExecution.isEmpty()) {
+            throw new TaskConfigurationException(
+                "It is prohibited to exclude common interceptors in default-properties, " +
+                    "excluded-common-execution-interceptors=[%s]".formatted(excludedCommonExecution)
+            );
+        }
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -162,6 +195,26 @@ public class TaskConfigurationDiscoveryProcessor {
             .map(taskProperties -> taskProperties.get(taskDef.getTaskName()))
             .orElse(null);
 
+        //interceptor lists have to be composed before the merge because merging mutates properties
+        List<Class<? extends TaskCreationInterceptor>> creationInterceptors = composeCreationInterceptors(
+            defaultConfTaskProperties,
+            customCodeTaskProperties,
+            customConfTaskProperties
+        );
+        List<Class<? extends TaskExecutionInterceptor>> executionInterceptors = composeExecutionInterceptors(
+            defaultConfTaskProperties,
+            customCodeTaskProperties,
+            customConfTaskProperties
+        );
+        List<Class<? extends CommonTaskCreationInterceptor>> excludedCommonCreationInterceptors = composeExcludedCommonCreationInterceptors(
+            customCodeTaskProperties,
+            customConfTaskProperties
+        );
+        List<Class<? extends CommonTaskExecutionInterceptor>> excludedCommonExecutionInterceptors = composeExcludedCommonExecutionInterceptors(
+            customCodeTaskProperties,
+            customConfTaskProperties
+        );
+
         var defaultTaskProperties = distributedTaskPropertiesMerger.merge(
             defaultCodeTaskProperties,
             defaultConfTaskProperties
@@ -175,7 +228,60 @@ public class TaskConfigurationDiscoveryProcessor {
             customTaskProperties
         );
 
-        return distributedTaskPropertiesMapper.map(taskProperties);
+        TaskSettings taskSettings = distributedTaskPropertiesMapper.map(taskProperties);
+        return taskSettings.toBuilder()
+            .creationInterceptors(creationInterceptors)
+            .executionInterceptors(executionInterceptors)
+            .excludedCommonCreationInterceptors(excludedCommonCreationInterceptors)
+            .excludedCommonExecutionInterceptors(excludedCommonExecutionInterceptors)
+            .build();
+    }
+
+    private static List<Class<? extends TaskCreationInterceptor>> composeCreationInterceptors(@Nullable DistributedTaskProperties.TaskProperties defaultConf,
+                                                                                               DistributedTaskProperties.TaskProperties customCode,
+                                                                                               @Nullable DistributedTaskProperties.TaskProperties customConf) {
+        return Stream.of(defaultConf, customCode, customConf)
+            .filter(Objects::nonNull)
+            .map(DistributedTaskProperties.TaskProperties::getCreationInterceptors)
+            .filter(Objects::nonNull)
+            .flatMap(Collection::stream)
+            .distinct()
+            .toList();
+    }
+
+    private static List<Class<? extends TaskExecutionInterceptor>> composeExecutionInterceptors(@Nullable DistributedTaskProperties.TaskProperties defaultConf,
+                                                                                                DistributedTaskProperties.TaskProperties customCode,
+                                                                                                @Nullable DistributedTaskProperties.TaskProperties customConf) {
+        return Stream.of(defaultConf, customCode, customConf)
+            .filter(Objects::nonNull)
+            .map(DistributedTaskProperties.TaskProperties::getExecutionInterceptors)
+            .filter(Objects::nonNull)
+            .flatMap(Collection::stream)
+            .distinct()
+            .toList();
+    }
+
+    //exclusions in default-properties are prohibited, see validateDefaultProperties()
+    private static List<Class<? extends CommonTaskCreationInterceptor>> composeExcludedCommonCreationInterceptors(DistributedTaskProperties.TaskProperties customCode,
+                                                                                                                  @Nullable DistributedTaskProperties.TaskProperties customConf) {
+        return Stream.of(customCode, customConf)
+            .filter(Objects::nonNull)
+            .map(DistributedTaskProperties.TaskProperties::getExcludedCommonCreationInterceptors)
+            .filter(Objects::nonNull)
+            .flatMap(Collection::stream)
+            .distinct()
+            .toList();
+    }
+
+    private static List<Class<? extends CommonTaskExecutionInterceptor>> composeExcludedCommonExecutionInterceptors(DistributedTaskProperties.TaskProperties customCode,
+                                                                                                                    @Nullable DistributedTaskProperties.TaskProperties customConf) {
+        return Stream.of(customCode, customConf)
+            .filter(Objects::nonNull)
+            .map(DistributedTaskProperties.TaskProperties::getExcludedCommonExecutionInterceptors)
+            .filter(Objects::nonNull)
+            .flatMap(Collection::stream)
+            .distinct()
+            .toList();
     }
 
     private DistributedTaskProperties.TaskProperties fillCustomProperties(Task<?> task) {
@@ -186,7 +292,33 @@ public class TaskConfigurationDiscoveryProcessor {
         fillDltMode(task, taskProperties);
         fillRetryMode(task, taskProperties);
         fillTaskTimeout(task, taskProperties);
+        fillCreationInterceptors(task, taskProperties);
+        fillExecutionInterceptors(task, taskProperties);
         return taskProperties;
+    }
+
+    private void fillCreationInterceptors(Task<?> task, DistributedTaskProperties.TaskProperties taskProperties) {
+        ReflectionHelper.findAnnotation(task, TaskCreationInterceptors.class)
+            .ifPresent(annotation -> {
+                if (annotation.value().length > 0) {
+                    taskProperties.setCreationInterceptors(List.of(annotation.value()));
+                }
+                if (annotation.excludedCommon().length > 0) {
+                    taskProperties.setExcludedCommonCreationInterceptors(List.of(annotation.excludedCommon()));
+                }
+            });
+    }
+
+    private void fillExecutionInterceptors(Task<?> task, DistributedTaskProperties.TaskProperties taskProperties) {
+        ReflectionHelper.findAnnotation(task, TaskExecutionInterceptors.class)
+            .ifPresent(annotation -> {
+                if (annotation.value().length > 0) {
+                    taskProperties.setExecutionInterceptors(List.of(annotation.value()));
+                }
+                if (annotation.excludedCommon().length > 0) {
+                    taskProperties.setExcludedCommonExecutionInterceptors(List.of(annotation.excludedCommon()));
+                }
+            });
     }
 
     private void fillTaskTimeout(Task<?> task, DistributedTaskProperties.TaskProperties taskSettings) {

--- a/core/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/annotation/TaskCreationInterceptors.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/annotation/TaskCreationInterceptors.java
@@ -1,0 +1,34 @@
+package com.distributed_task_framework.autoconfigure.annotation;
+
+import com.distributed_task_framework.interceptor.CommonTaskCreationInterceptor;
+import com.distributed_task_framework.interceptor.TaskCreationInterceptor;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Convenient approach to attach creation interceptors to a task.
+ * Combined with default interceptors from the config and deduplicated.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface TaskCreationInterceptors {
+
+    /**
+     * Classes of {@link TaskCreationInterceptor} implementations.
+     *
+     * @return
+     */
+    Class<? extends TaskCreationInterceptor>[] value() default {};
+
+    /**
+     * Classes of common creation interceptors excluded for the task.
+     *
+     * @return
+     */
+    Class<? extends CommonTaskCreationInterceptor>[] excludedCommon() default {};
+}

--- a/core/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/annotation/TaskExecutionInterceptors.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/annotation/TaskExecutionInterceptors.java
@@ -1,0 +1,34 @@
+package com.distributed_task_framework.autoconfigure.annotation;
+
+import com.distributed_task_framework.interceptor.CommonTaskExecutionInterceptor;
+import com.distributed_task_framework.interceptor.TaskExecutionInterceptor;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Convenient approach to attach execution interceptors to a task.
+ * Combined with default interceptors from the config and deduplicated.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface TaskExecutionInterceptors {
+
+    /**
+     * Classes of {@link TaskExecutionInterceptor} implementations.
+     *
+     * @return
+     */
+    Class<? extends TaskExecutionInterceptor>[] value() default {};
+
+    /**
+     * Classes of common execution interceptors excluded for the task.
+     *
+     * @return
+     */
+    Class<? extends CommonTaskExecutionInterceptor>[] excludedCommon() default {};
+}

--- a/core/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/mapper/DistributedTaskPropertiesMerger.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/main/java/com/distributed_task_framework/autoconfigure/mapper/DistributedTaskPropertiesMerger.java
@@ -2,6 +2,7 @@ package com.distributed_task_framework.autoconfigure.mapper;
 
 import com.distributed_task_framework.autoconfigure.DistributedTaskProperties;
 import jakarta.annotation.Nullable;
+import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.MappingTarget;
@@ -10,7 +11,8 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 @Mapper(
     componentModel = MappingConstants.ComponentModel.SPRING,
     uses = RetrySettingsMerger.class,
-    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
+    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+    collectionMappingStrategy = CollectionMappingStrategy.TARGET_IMMUTABLE
 )
 public interface DistributedTaskPropertiesMerger {
 

--- a/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/DistributedTaskPropertiesBindingTest.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/DistributedTaskPropertiesBindingTest.java
@@ -1,0 +1,40 @@
+package com.distributed_task_framework.autoconfigure;
+
+import com.distributed_task_framework.autoconfigure.tasks.TestCreationInterceptor;
+import com.distributed_task_framework.autoconfigure.tasks.TestCreationInterceptorTwo;
+import com.distributed_task_framework.autoconfigure.tasks.TestExecutionInterceptor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DistributedTaskPropertiesBindingTest {
+
+    @Test
+    void shouldBindInterceptorClasses() {
+        //when
+        Binder binder = new Binder(new MapConfigurationPropertySource(Map.of(
+            "distributed-task.task-properties-group.default-properties.creation-interceptors[0]",
+                "com.distributed_task_framework.autoconfigure.tasks.TestCreationInterceptor",
+            "distributed-task.task-properties-group.default-properties.creation-interceptors[1]",
+                "com.distributed_task_framework.autoconfigure.tasks.TestCreationInterceptorTwo",
+            "distributed-task.task-properties-group.default-properties.execution-interceptors[0]",
+                "com.distributed_task_framework.autoconfigure.tasks.TestExecutionInterceptor"
+        )));
+
+        //do
+        DistributedTaskProperties properties = binder
+            .bind("distributed-task", Bindable.of(DistributedTaskProperties.class))
+            .orElseThrow(IllegalStateException::new);
+
+        //verify
+        assertThat(properties.getTaskPropertiesGroup().getDefaultProperties().getCreationInterceptors())
+            .containsExactly(TestCreationInterceptor.class, TestCreationInterceptorTwo.class);
+        assertThat(properties.getTaskPropertiesGroup().getDefaultProperties().getExecutionInterceptors())
+            .containsExactly(TestExecutionInterceptor.class);
+    }
+}

--- a/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/TaskConfigurationDiscoveryProcessorTest.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/TaskConfigurationDiscoveryProcessorTest.java
@@ -6,6 +6,13 @@ import com.distributed_task_framework.autoconfigure.tasks.CustomTaskWithOffRetry
 import com.distributed_task_framework.autoconfigure.tasks.CustomizedTask;
 import com.distributed_task_framework.autoconfigure.tasks.DefaultTask;
 import com.distributed_task_framework.autoconfigure.tasks.SimpleCronCustomizedTask;
+import com.distributed_task_framework.autoconfigure.tasks.TaskWithExcludedCommonInterceptors;
+import com.distributed_task_framework.autoconfigure.tasks.TaskWithInterceptors;
+import com.distributed_task_framework.autoconfigure.tasks.TestCreationInterceptor;
+import com.distributed_task_framework.autoconfigure.tasks.TestCreationInterceptorThree;
+import com.distributed_task_framework.autoconfigure.tasks.TestCreationInterceptorTwo;
+import com.distributed_task_framework.autoconfigure.tasks.TestExecutionInterceptor;
+import com.distributed_task_framework.exception.TaskConfigurationException;
 import com.distributed_task_framework.model.ExecutionContext;
 import com.distributed_task_framework.model.TaskDef;
 import com.distributed_task_framework.service.DistributedTaskService;
@@ -35,6 +42,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.distributed_task_framework.autoconfigure.TaskConfigurationDiscoveryProcessor.EMPTY_TASK_SETTINGS_CUSTOMIZER;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -294,6 +302,141 @@ class TaskConfigurationDiscoveryProcessorTest {
         //verify
         verify(distributedTaskService)
             .registerRemoteTask(eq(remoteTaskDef), eq(taskSettings));
+    }
+
+    @Test
+    void shouldRegistryLocalTaskWithInterceptorsFromCode() {
+        //when
+        TaskWithInterceptors task = new TaskWithInterceptors();
+        tasks.add(task);
+
+        //do
+        taskConfigurationDiscoveryProcessor.init();
+
+        //verify
+        TaskSettings taskSettings = TaskSettings.DEFAULT.toBuilder()
+            .creationInterceptors(List.of(TestCreationInterceptor.class))
+            .executionInterceptors(List.of(TestExecutionInterceptor.class))
+            .build();
+        verifyTaskIsRegistered(task, taskSettings);
+    }
+
+    @Test
+    void shouldRegistryLocalTaskWithExcludedCommonInterceptorsFromCode() {
+        //when
+        TaskWithExcludedCommonInterceptors task = new TaskWithExcludedCommonInterceptors();
+        tasks.add(task);
+
+        //do
+        taskConfigurationDiscoveryProcessor.init();
+
+        //verify
+        TaskSettings taskSettings = TaskSettings.DEFAULT.toBuilder()
+            .excludedCommonCreationInterceptors(List.of(TestCreationInterceptor.class))
+            .excludedCommonExecutionInterceptors(List.of(TestExecutionInterceptor.class))
+            .build();
+        verifyTaskIsRegistered(task, taskSettings);
+    }
+
+    @Test
+    void shouldAppendAndDeduplicateExcludedCommonInterceptorsFromFileAndCode() {
+        //when
+        TaskWithExcludedCommonInterceptors task = new TaskWithExcludedCommonInterceptors();
+        when(properties.getTaskPropertiesGroup()).thenReturn(DistributedTaskProperties.TaskPropertiesGroup.builder()
+            .taskProperties(Map.of(
+                task.getDef().getTaskName(),
+                DistributedTaskProperties.TaskProperties.builder()
+                    .excludedCommonCreationInterceptors(List.of(TestCreationInterceptorTwo.class, TestCreationInterceptorThree.class))
+                    .excludedCommonExecutionInterceptors(List.of(TestExecutionInterceptor.class))
+                    .build()
+            ))
+            .build());
+        tasks.add(task);
+
+        //do
+        taskConfigurationDiscoveryProcessor.init();
+
+        //verify
+        TaskSettings taskSettings = TaskSettings.DEFAULT.toBuilder()
+            .excludedCommonCreationInterceptors(List.of(
+                TestCreationInterceptor.class,
+                TestCreationInterceptorTwo.class,
+                TestCreationInterceptorThree.class
+            ))
+            .excludedCommonExecutionInterceptors(List.of(TestExecutionInterceptor.class))
+            .build();
+        verifyTaskIsRegistered(task, taskSettings);
+    }
+
+    @Test
+    void shouldThrowWhenExcludingCommonInterceptorsInDefaultProperties() {
+        //when
+        when(properties.getTaskPropertiesGroup()).thenReturn(DistributedTaskProperties.TaskPropertiesGroup.builder()
+            .defaultProperties(DistributedTaskProperties.TaskProperties.builder()
+                .excludedCommonCreationInterceptors(List.of(TestCreationInterceptor.class))
+                .build())
+            .build());
+        tasks.add(new DefaultTask());
+
+        //do/verify
+        assertThatThrownBy(() -> taskConfigurationDiscoveryProcessor.init())
+            .isInstanceOf(TaskConfigurationException.class)
+            .hasMessageContaining("prohibited");
+    }
+
+    @Test
+    void shouldRegistryLocalTaskWithDefaultInterceptorsFromFile() {
+        //when
+        when(properties.getTaskPropertiesGroup()).thenReturn(DistributedTaskProperties.TaskPropertiesGroup.builder()
+            .defaultProperties(DistributedTaskProperties.TaskProperties.builder()
+                .creationInterceptors(List.of(TestCreationInterceptor.class))
+                .executionInterceptors(List.of(TestExecutionInterceptor.class))
+                .build())
+            .build());
+        DefaultTask defaultTask = new DefaultTask();
+        tasks.add(defaultTask);
+
+        //do
+        taskConfigurationDiscoveryProcessor.init();
+
+        //verify
+        TaskSettings taskSettings = TaskSettings.DEFAULT.toBuilder()
+            .creationInterceptors(List.of(TestCreationInterceptor.class))
+            .executionInterceptors(List.of(TestExecutionInterceptor.class))
+            .build();
+        verifyTaskIsRegistered(defaultTask, taskSettings);
+    }
+
+    @Test
+    void shouldAppendAndDeduplicateInterceptorsFromFileAndCode() {
+        //when
+        TaskWithInterceptors task = new TaskWithInterceptors();
+        when(properties.getTaskPropertiesGroup()).thenReturn(DistributedTaskProperties.TaskPropertiesGroup.builder()
+            .defaultProperties(DistributedTaskProperties.TaskProperties.builder()
+                .creationInterceptors(List.of(TestCreationInterceptor.class, TestCreationInterceptorTwo.class))
+                .build())
+            .taskProperties(Map.of(
+                task.getDef().getTaskName(),
+                DistributedTaskProperties.TaskProperties.builder()
+                    .creationInterceptors(List.of(TestCreationInterceptorTwo.class, TestCreationInterceptorThree.class))
+                    .build()
+            ))
+            .build());
+        tasks.add(task);
+
+        //do
+        taskConfigurationDiscoveryProcessor.init();
+
+        //verify
+        TaskSettings taskSettings = TaskSettings.DEFAULT.toBuilder()
+            .creationInterceptors(List.of(
+                TestCreationInterceptor.class,
+                TestCreationInterceptorTwo.class,
+                TestCreationInterceptorThree.class
+            ))
+            .executionInterceptors(List.of(TestExecutionInterceptor.class))
+            .build();
+        verifyTaskIsRegistered(task, taskSettings);
     }
 
     private DistributedTaskProperties.TaskPropertiesGroup buildCustomConfig() {

--- a/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/tasks/TaskWithExcludedCommonInterceptors.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/tasks/TaskWithExcludedCommonInterceptors.java
@@ -1,0 +1,32 @@
+package com.distributed_task_framework.autoconfigure.tasks;
+
+import com.distributed_task_framework.model.TaskDef;
+import com.distributed_task_framework.autoconfigure.annotation.TaskCreationInterceptors;
+import com.distributed_task_framework.autoconfigure.annotation.TaskExecutionInterceptors;
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.FailedExecutionContext;
+import com.distributed_task_framework.task.Task;
+import org.springframework.stereotype.Component;
+
+@Component
+@TaskCreationInterceptors(excludedCommon = {
+    TestCreationInterceptor.class
+})
+@TaskExecutionInterceptors(excludedCommon = {
+    TestExecutionInterceptor.class
+})
+public class TaskWithExcludedCommonInterceptors implements Task<Void> {
+
+    @Override
+    public TaskDef<Void> getDef() {
+        return TaskDef.privateTaskDef("task_with_excluded_common_interceptors", Void.class);
+    }
+
+    @Override
+    public void execute(ExecutionContext<Void> executionContext) throws Exception {
+    }
+
+    @Override
+    public void onFailure(FailedExecutionContext<Void> failedExecutionContext) {
+    }
+}

--- a/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/tasks/TaskWithInterceptors.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/tasks/TaskWithInterceptors.java
@@ -1,0 +1,32 @@
+package com.distributed_task_framework.autoconfigure.tasks;
+
+import com.distributed_task_framework.model.TaskDef;
+import com.distributed_task_framework.autoconfigure.annotation.TaskCreationInterceptors;
+import com.distributed_task_framework.autoconfigure.annotation.TaskExecutionInterceptors;
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.FailedExecutionContext;
+import com.distributed_task_framework.task.Task;
+import org.springframework.stereotype.Component;
+
+@Component
+@TaskCreationInterceptors({
+    TestCreationInterceptor.class
+})
+@TaskExecutionInterceptors({
+    TestExecutionInterceptor.class
+})
+public class TaskWithInterceptors implements Task<Void> {
+
+    @Override
+    public TaskDef<Void> getDef() {
+        return TaskDef.privateTaskDef("task_with_interceptors", Void.class);
+    }
+
+    @Override
+    public void execute(ExecutionContext<Void> executionContext) throws Exception {
+    }
+
+    @Override
+    public void onFailure(FailedExecutionContext<Void> failedExecutionContext) {
+    }
+}

--- a/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/tasks/TestCreationInterceptor.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/tasks/TestCreationInterceptor.java
@@ -1,0 +1,13 @@
+package com.distributed_task_framework.autoconfigure.tasks;
+
+import com.distributed_task_framework.interceptor.CommonTaskCreationInterceptor;
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.TaskDef;
+
+public class TestCreationInterceptor implements CommonTaskCreationInterceptor {
+
+    @Override
+    public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+        return executionContext;
+    }
+}

--- a/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/tasks/TestCreationInterceptorThree.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/tasks/TestCreationInterceptorThree.java
@@ -1,0 +1,13 @@
+package com.distributed_task_framework.autoconfigure.tasks;
+
+import com.distributed_task_framework.interceptor.CommonTaskCreationInterceptor;
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.TaskDef;
+
+public class TestCreationInterceptorThree implements CommonTaskCreationInterceptor {
+
+    @Override
+    public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+        return executionContext;
+    }
+}

--- a/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/tasks/TestCreationInterceptorTwo.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/tasks/TestCreationInterceptorTwo.java
@@ -1,0 +1,13 @@
+package com.distributed_task_framework.autoconfigure.tasks;
+
+import com.distributed_task_framework.interceptor.CommonTaskCreationInterceptor;
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.TaskDef;
+
+public class TestCreationInterceptorTwo implements CommonTaskCreationInterceptor {
+
+    @Override
+    public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+        return executionContext;
+    }
+}

--- a/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/tasks/TestExecutionInterceptor.java
+++ b/core/distributed-task-spring-boot-autoconfigure/src/test/java/com/distributed_task_framework/autoconfigure/tasks/TestExecutionInterceptor.java
@@ -1,0 +1,14 @@
+package com.distributed_task_framework.autoconfigure.tasks;
+
+import com.distributed_task_framework.interceptor.CommonTaskExecutionInterceptor;
+import com.distributed_task_framework.interceptor.TaskExecutionChain;
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.TaskDef;
+
+public class TestExecutionInterceptor implements CommonTaskExecutionInterceptor {
+
+    @Override
+    public <U> void execute(ExecutionContext<U> executionContext, TaskDef<U> taskDef, TaskExecutionChain chain) throws Exception {
+        chain.proceed();
+    }
+}

--- a/core/distributed-task-spring-boot-autoconfigure/src/test/resources/db/test-changelog/db.changelog-aggregator.yaml
+++ b/core/distributed-task-spring-boot-autoconfigure/src/test/resources/db/test-changelog/db.changelog-aggregator.yaml
@@ -7,3 +7,5 @@ databaseChangeLog:
       file: db/changelog/distributed-task-framework/db.changelog-dtf-003-feature-wait-task.yaml
   - include:
       file: db/changelog/distributed-task-framework/db.changelog-dtf-004-feature-statefull-task.yaml
+  - include:
+      file: db/changelog/distributed-task-framework/db.changelog-dtf-005-feature-metadata.yaml

--- a/examples/distributed-task-test-application/src/main/java/com/distributed_task_framework/test_service/controllers/TestTaskController.java
+++ b/examples/distributed-task-test-application/src/main/java/com/distributed_task_framework/test_service/controllers/TestTaskController.java
@@ -1,6 +1,7 @@
 package com.distributed_task_framework.test_service.controllers;
 
 import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.Metadata;
 import com.distributed_task_framework.service.DistributedTaskService;
 import com.distributed_task_framework.test_service.tasks.PrivateTaskDefinitions;
 import com.distributed_task_framework.test_service.tasks.dto.SimpleMessageDto;
@@ -54,6 +55,17 @@ public class TestTaskController {
         distributedTaskService.schedule(
             MAP_REDUCE_PARENT_TASK,
             withAffinityGroup(dto, MAP_REDUCE_AFFINITY_GROUP, UUID.randomUUID().toString())
+        );
+    }
+
+    @Operation(summary = "Schedule task with metadata (see tasks/metadata package)")
+    @PostMapping("metadata")
+    public void createTaskWithMetadata(@RequestBody(required = false) SimpleMessageDto simpleMessageDto) throws Exception {
+        // metadata set via API; TraceIdCreationInterceptor adds more (see application.yml)
+        distributedTaskService.schedule(
+            PrivateTaskDefinitions.METADATA_EXAMPLE_TASK_DEF,
+            ExecutionContext.simple(simpleMessageDto)
+                .withMetadata(Metadata.of("tenant", "test-app").add("tags", "demo", "metadata"))
         );
     }
 }

--- a/examples/distributed-task-test-application/src/main/java/com/distributed_task_framework/test_service/tasks/PrivateTaskDefinitions.java
+++ b/examples/distributed-task-test-application/src/main/java/com/distributed_task_framework/test_service/tasks/PrivateTaskDefinitions.java
@@ -62,4 +62,8 @@ public interface PrivateTaskDefinitions {
     TaskDef<Void> TEST_OOM_TASK = TaskDef.privateTaskDef("TEST_OOM_TASK", Void.class);
 
     TaskDef<Void> CHECK_TIMEOUT_TASK = TaskDef.privateTaskDef("CHECK_TIMEOUT_TASK", Void.class);
+
+    //---- Example of task with metadata ------
+    TaskDef<SimpleMessageDto> METADATA_EXAMPLE_TASK_DEF = TaskDef.privateTaskDef("METADATA_EXAMPLE_TASK", SimpleMessageDto.class);
+    //----------------------------------------
 }

--- a/examples/distributed-task-test-application/src/main/java/com/distributed_task_framework/test_service/tasks/metadata/LoggingExecutionInterceptor.java
+++ b/examples/distributed-task-test-application/src/main/java/com/distributed_task_framework/test_service/tasks/metadata/LoggingExecutionInterceptor.java
@@ -1,0 +1,35 @@
+package com.distributed_task_framework.test_service.tasks.metadata;
+
+import com.distributed_task_framework.interceptor.TaskExecutionChain;
+import com.distributed_task_framework.interceptor.TaskExecutionInterceptor;
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.TaskDef;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Logs metadata around execution and measures execution time
+ * for every task it is attached to (see MetadataExampleTask).
+ */
+@Slf4j
+@Component
+public class LoggingExecutionInterceptor implements TaskExecutionInterceptor {
+
+    @Override
+    public <U> void execute(ExecutionContext<U> executionContext, TaskDef<U> taskDef, TaskExecutionChain chain) throws Exception {
+        long start = System.nanoTime();
+        log.info("execution started: taskName=[{}], taskId=[{}], metadata=[{}]",
+            taskDef.getTaskName(),
+            executionContext.getCurrentTaskId(),
+            executionContext.getMetadata()
+        );
+        try {
+            chain.proceed();
+        } finally {
+            log.info("execution finished: taskId=[{}], took=[{}ms]",
+                executionContext.getCurrentTaskId(),
+                (System.nanoTime() - start) / 1_000_000
+            );
+        }
+    }
+}

--- a/examples/distributed-task-test-application/src/main/java/com/distributed_task_framework/test_service/tasks/metadata/MetadataExampleTask.java
+++ b/examples/distributed-task-test-application/src/main/java/com/distributed_task_framework/test_service/tasks/metadata/MetadataExampleTask.java
@@ -1,0 +1,55 @@
+package com.distributed_task_framework.test_service.tasks.metadata;
+
+import com.distributed_task_framework.autoconfigure.annotation.TaskCreationInterceptors;
+import com.distributed_task_framework.autoconfigure.annotation.TaskExecutionInterceptors;
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.FailedExecutionContext;
+import com.distributed_task_framework.model.Metadata;
+import com.distributed_task_framework.model.TaskDef;
+import com.distributed_task_framework.service.DistributedTaskService;
+import com.distributed_task_framework.task.Task;
+import com.distributed_task_framework.test_service.tasks.PrivateTaskDefinitions;
+import com.distributed_task_framework.test_service.tasks.dto.ComplexMessageDto;
+import com.distributed_task_framework.test_service.tasks.dto.SimpleMessageDto;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@RequiredArgsConstructor
+@Component
+@TaskCreationInterceptors(TraceIdCreationInterceptor.class)
+@TaskExecutionInterceptors(LoggingExecutionInterceptor.class)
+public class MetadataExampleTask implements Task<SimpleMessageDto> {
+    DistributedTaskService distributedTaskService;
+
+    @Override
+    public TaskDef<SimpleMessageDto> getDef() {
+        return PrivateTaskDefinitions.METADATA_EXAMPLE_TASK_DEF;
+    }
+
+    @Override
+    public void execute(ExecutionContext<SimpleMessageDto> executionContext) throws Exception {
+        // metadata is set via API and by TraceIdCreationInterceptor
+        Metadata metadata = executionContext.getMetadata();
+        log.info("metadata example: traceId=[{}], tenant=[{}], tags=[{}]",
+            metadata.getSingle("traceId").orElse("unknown"),
+            metadata.getSingle("tenant").orElse("unknown"),
+            metadata.get("tags")
+        );
+
+        // metadata is inherited by child tasks scheduled with withXXX methods
+        distributedTaskService.schedule(
+            PrivateTaskDefinitions.SIMPLE_CONSOLE_OUTPUT_2_TASK_DEF,
+            executionContext.withNewMessage(ComplexMessageDto.builder().build())
+        );
+    }
+
+    @Override
+    public void onFailure(FailedExecutionContext<SimpleMessageDto> failedExecutionContext) {
+        log.error("metadata example failed: {}", failedExecutionContext.toString());
+    }
+}

--- a/examples/distributed-task-test-application/src/main/java/com/distributed_task_framework/test_service/tasks/metadata/TraceIdCreationInterceptor.java
+++ b/examples/distributed-task-test-application/src/main/java/com/distributed_task_framework/test_service/tasks/metadata/TraceIdCreationInterceptor.java
@@ -1,0 +1,24 @@
+package com.distributed_task_framework.test_service.tasks.metadata;
+
+import com.distributed_task_framework.interceptor.TaskCreationInterceptor;
+import com.distributed_task_framework.model.ExecutionContext;
+import com.distributed_task_framework.model.TaskDef;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * Adds metadata to every task it is attached to (see MetadataExampleTask).
+ */
+@Component
+public class TraceIdCreationInterceptor implements TaskCreationInterceptor {
+
+    @Override
+    public <U> ExecutionContext<U> onTaskCreated(ExecutionContext<U> executionContext, TaskDef<U> taskDef) {
+        return executionContext.withMetadata(
+            executionContext.getMetadata()
+                .withIfAbsent("traceId", UUID.randomUUID().toString())
+                .add("intercepted", "true")
+        );
+    }
+}

--- a/examples/distributed-task-test-application/src/main/resources/application.yml
+++ b/examples/distributed-task-test-application/src/main/resources/application.yml
@@ -68,6 +68,14 @@ distributed-task:
       max-parallel-in-cluster: 100
 #      max-parallel-in-node: 1
       timeout: PT10S
+      excluded-common-creation-interceptors:
+    #      # metadata example: apply interceptors to all tasks via yaml
+#      # (for METADATA_EXAMPLE_TASK interceptors are attached via annotations instead,
+#      #  see tasks/metadata/MetadataExampleTask.java)
+#      creation-interceptors:
+#        - com.distributed_task_framework.test_service.tasks.metadata.TraceIdCreationInterceptor
+#      execution-interceptors:
+#        - com.distributed_task_framework.test_service.tasks.metadata.LoggingExecutionInterceptor
 
     task-properties:
       CRON_TEST_TASK_DEF:
@@ -86,3 +94,10 @@ distributed-task:
             max-retries: 1000
             max-delay: PT1H
         max-parallel-in-cluster: 100
+#      # metadata example: interceptors attached to a single task via yaml
+#      # (alternative to annotations, see tasks/metadata/MetadataExampleTask.java)
+#      METADATA_EXAMPLE_TASK:
+#        creation-interceptors:
+#          - com.distributed_task_framework.test_service.tasks.metadata.TraceIdCreationInterceptor
+#        execution-interceptors:
+#          - com.distributed_task_framework.test_service.tasks.metadata.LoggingExecutionInterceptor


### PR DESCRIPTION
introduce task metadata as one of way to pass additional meta data (like request-id for MDC) into task. 